### PR TITLE
Support the `protocol_version` guest callback

### DIFF
--- a/mod.go
+++ b/mod.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const PROTOCOL_VERSION = "v1"
+
 // Message is the optional string used to build validation responses
 type Message string
 
@@ -74,4 +76,10 @@ func RejectSettings(message Message) ([]byte, error) {
 		stringResult = append(stringResult, keyValue.String())
 	}
 	return []byte(fmt.Sprintf("{%s}", strings.Join(stringResult, ","))), nil
+}
+
+/// ProtocolVersionCallback is the implementation of the `protocol_version` waPC
+/// guest function. This returns the protocol version the policy supports.
+func ProtocolVersionCallback(_ []byte) ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, PROTOCOL_VERSION)), nil
 }


### PR DESCRIPTION
Implement the `protocol_version` callback function that can be used by Go policy authors

Fixes https://github.com/kubewarden/policy-sdk-go/issues/5