### PR TITLE
Provide logging capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,58 @@ language.
 Due to current Go compiler limitations, Go policies must be built
 using [TinyGo](https://github.com/tinygo-org/tinygo).
 
+## Validation
+
+This SDK provides helper methods to accept and reject validation requests.
+
+Mutation policies cannot be written using this policy yet.
+
+## Logging
+
+Policies can generate log messages that are then propagated to the host
+environment (eg: [kwctl](https://github.com/kubewarden/kwctl),
+[policy-server](https://github.com/kubewarden/policy-server)).
+
+This Go module provides logging capabilities that integrate with the
+[onelog](https://github.com/francoispqt/onelog) project.
+
+This logging solution has been chosen because:
+
+  * It works also with WebAssembly binaries. Other popular logging solutions
+    cannot even be built to WebAssembly.
+  * It provides [good performance](https://github.com/francoispqt/onelog#benchmarks)
+  * It supports structured logging.
+
+### Usage
+
+The instructions provided by the official
+[onelog](https://github.com/francoispqt/onelog) project apply also to Kubewarden
+policies.
+
+The `onelog.Logger` instance must be configured to use a `KubewardenLogWriter`
+object.
+
+```go
+	kl := kubewarden.KubewardenLogWriter{}
+	logger := onelog.New(
+		&kl,
+		onelog.ALL, // shortcut for onelog.DEBUG|onelog.INFO|onelog.WARN|onelog.ERROR|onelog.FATAL,
+	)
+	logger.Info("info message from tinygo")
+	logger.DebugWithFields("i'm not sure what's going on", func(e onelog.Entry) {
+		e.String("string", "foobar")
+		e.Int("int", 12345)
+		e.Int64("int64", 12345)
+		e.Float("float64", 0.15)
+		e.Bool("bool", true)
+		e.Err("err", errors.New("someError"))
+		e.ObjectFunc("user", func(e onelog.Entry) {
+			e.String("name", "somename")
+		})
+	})
+```
+
+
 ## Testing
 
 [![GoDoc](https://godoc.org/github.com/kubewarden/policy-sdk-go/testing?status.svg)](https://godoc.org/github.com/kubewarden/policy-sdk-go/testing)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ using [TinyGo](https://github.com/tinygo-org/tinygo).
 
 This SDK provides helper methods to accept and reject validation requests.
 
-Mutation policies cannot be written using this policy yet.
+Mutation policies cannot be written using this SDK yet.
 
 ## Logging
 

--- a/kubewarden.go
+++ b/kubewarden.go
@@ -1,3 +1,6 @@
+// This package provides helper functions and structs for writing
+// https://kubewarden.io policies using the Go programming
+// language.
 package sdk
 
 import (

--- a/log_writer.go
+++ b/log_writer.go
@@ -1,0 +1,18 @@
+package sdk
+
+import (
+	"bytes"
+)
+
+// KubewardenLogWriter is a simple log collector that can be used
+// with a `onelog.Logger` instance.
+//
+// KubewardenLogWriter will send the logs from the WebAssembly guest (the policy)
+// to the WebAssembly host (kwct, policy-server).
+//
+// KubewardenLogWriter will write the log events to the standard output when the
+// binary is NOT built for the WebAssembly target. This is useful for running
+// native unit tests of policies.
+type KubewardenLogWriter struct {
+	buffer bytes.Buffer
+}

--- a/log_writer_native.go
+++ b/log_writer_native.go
@@ -1,0 +1,17 @@
+// +build !wasi
+
+// note well: we have to use the tinygo wasi target, because the wasm one is
+// meant to be used inside of the browser
+
+package sdk
+
+import (
+	"fmt"
+)
+
+func (k *KubewardenLogWriter) Write(p []byte) (n int, err error) {
+	n, err = k.buffer.Write(p)
+	line, _ := k.buffer.ReadBytes('\n')
+	fmt.Printf("NATIVE: |%s|\n", string(line))
+	return
+}

--- a/log_writer_wasi.go
+++ b/log_writer_wasi.go
@@ -1,0 +1,17 @@
+// +build wasi
+
+// note well: we have to use the tinygo wasi target, because the wasm one is
+// meant to be used inside of the browser
+
+package sdk
+
+import (
+	wapc "github.com/wapc/wapc-guest-tinygo"
+)
+
+func (k *KubewardenLogWriter) Write(p []byte) (n int, err error) {
+	n, err = k.buffer.Write(p)
+	line, _ := k.buffer.ReadBytes('\n')
+	wapc.HostCall("kubewarden", "tracing", "log", line)
+	return
+}


### PR DESCRIPTION
Extend the SDK to allow policy authors to generate logs from their policies.

Fixes https://github.com/kubewarden/policy-sdk-go/issues/9