### PR TITLE
feat: Add host_capabilities package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module github.com/kubewarden/policy-sdk-go
 
 go 1.15
 
-require github.com/wapc/wapc-guest-tinygo v0.3.1
+require (
+	github.com/tidwall/gjson v1.14.1
+	github.com/tidwall/sjson v1.2.4
+	github.com/wapc/wapc-guest-tinygo v0.3.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
+github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.1 h1:iymTbGkQBhveq21bEvAQ81I0LEBork8BFe1CUZXdyuo=
+github.com/tidwall/gjson v1.14.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.4 h1:cuiLzLnaMeBhRmEv00Lpk3tkYrcxpmbU81tAY4Dw0tc=
+github.com/tidwall/sjson v1.2.4/go.mod h1:098SZ494YoMWPmMO6ct4dcFnqxwj9r/gF0Etp19pSNM=
 github.com/wapc/wapc-guest-tinygo v0.3.1 h1:ecmT4W+ynsNvRvLolPw2rQRafCAoLMh7L/u6ZxVSWXU=
 github.com/wapc/wapc-guest-tinygo v0.3.1/go.mod h1:Jssn+ovE+Y2oueUgVeLyGZf2ipUPngVnWTNPM8zmhn0=

--- a/host_capabilities/hostcaller.go
+++ b/host_capabilities/hostcaller.go
@@ -1,6 +1,6 @@
-// This package provides functions and structs for making host calls against the
-// waPC host. These functions are normally used when deciding if to validate a
-// request on a policy or not.
+// This package provides access to the structs and functions offered by the Kubewarden host.
+// This allows policies to perform operations that are not doable inside of the WebAssembly
+// runtime. Such as, policy verification, reverse DNS lookups, interacting with OCI registries,...
 package host_capabilities
 
 type HostCaller interface {

--- a/host_capabilities/hostcaller.go
+++ b/host_capabilities/hostcaller.go
@@ -1,0 +1,70 @@
+// This package provides functions and structs for making host calls against the
+// waPC host. These functions are normally used when deciding if to validate a
+// request on a policy or not.
+package host_capabilities
+
+type HostCaller interface {
+
+	// GetOCIManifest computes the digest of the OCI object referenced by image
+	GetOCIManifest(image string) (digest string, err error)
+
+	// LookupHost looks up the addresses for a given hostname via DNS
+	LookupHost(host string) (listIPs []string, err error)
+
+	// VerifyPubKeys verifies sigstore signatures of an image using public keys
+	// Arguments
+	// * image: image to be verified
+	// * pubKeys: list of PEM encoded keys that must have been used to sign the OCI object
+	// * annotations: annotations that must have been provided by all signers when they signed the OCI artifact
+	VerifyPubKeys(image string, pubKeys []string, annotations map[string]string) (VerificationResponse, error)
+
+	// VerifyKeyless verifies sigstore signatures of an image using keyless signing
+	// Arguments
+	// * image: image to be verified
+	// * keyless: list of KeylessInfo pairs, containing Issuer and Subject info from OIDC providers
+	// * annotations: annotations that must have been provided by all signers when they signed the OCI artifact
+	VerifyKeyless(image string, keyless []KeylessInfo, annotations map[string]string) (VerificationResponse, error)
+}
+
+type KeylessInfo struct {
+	// Issuer is identifier of the OIDC provider. E.g: https://github.com/login/oauth
+	Issuer string `json:"issuer"`
+	// Subject contains the information of the user used to authenticate against
+	// the OIDC provider. E.g: mail@example.com
+	Subject string `json:"subject"`
+}
+
+type VerificationResponse struct {
+	// informs if the image was verified or not
+	IsTrusted bool `json:"is_trusted"`
+	// digest of the verified image
+	Digest string `json:"digest"`
+}
+
+// sigstorePubKeysVerify represents the WaPC JSON contract, used for marshalling
+// and unmarshalling payloads to wapc host calls
+//
+// Note: this is not in use for wasi, as we use gjson and sjson
+type sigstorePubKeysVerify struct {
+	// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+	Image string `json:"image"`
+	// List of PEM encoded keys that must have been used to sign the OCI object
+	PubKeys []string `json:"pub_keys"`
+	// Annotations that must have been provided by all signers when they signed
+	// the OCI artifact. Optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// sigstoreKeylessVerify represents the WaPC JSON contract, used for marshalling
+// and unmarshalling payloads to wapc host calls
+//
+// Note: this is not in use for wasi, as we use gjson and sjson
+type sigstoreKeylessVerify struct {
+	// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
+	Image string `json:"image"`
+	// List of PEM encoded keys that must have been used to sign the OCI object
+	Keyless []KeylessInfo `json:"keyless"`
+	// Annotations that must have been provided by all signers when they signed
+	// the OCI artifact. Optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/host_capabilities/hostcaller.go
+++ b/host_capabilities/hostcaller.go
@@ -6,6 +6,8 @@ package host_capabilities
 type HostCaller interface {
 
 	// GetOCIManifest computes the digest of the OCI object referenced by image
+	// Arguments:
+	// * image: image to be verified (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	GetOCIManifest(image string) (digest string, err error)
 
 	// LookupHost looks up the addresses for a given hostname via DNS

--- a/host_capabilities/hostcaller.go
+++ b/host_capabilities/hostcaller.go
@@ -13,7 +13,7 @@ type HostCaller interface {
 
 	// VerifyPubKeys verifies sigstore signatures of an image using public keys
 	// Arguments
-	// * image: image to be verified
+	// * image: image to be verified (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	// * pubKeys: list of PEM encoded keys that must have been used to sign the OCI object
 	// * annotations: annotations that must have been provided by all signers when they signed the OCI artifact
 	VerifyPubKeys(image string, pubKeys []string, annotations map[string]string) (VerificationResponse, error)

--- a/host_capabilities/hostcaller.go
+++ b/host_capabilities/hostcaller.go
@@ -20,7 +20,7 @@ type HostCaller interface {
 
 	// VerifyKeyless verifies sigstore signatures of an image using keyless signing
 	// Arguments
-	// * image: image to be verified
+	// * image: image to be verified (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	// * keyless: list of KeylessInfo pairs, containing Issuer and Subject info from OIDC providers
 	// * annotations: annotations that must have been provided by all signers when they signed the OCI artifact
 	VerifyKeyless(image string, keyless []KeylessInfo, annotations map[string]string) (VerificationResponse, error)

--- a/host_capabilities/hostcaller_native.go
+++ b/host_capabilities/hostcaller_native.go
@@ -1,0 +1,82 @@
+// +build !wasi
+
+// note well: we have to use the tinygo wasi target, because the wasm one is
+// meant to be used inside of the browser
+
+package host_capabilities
+
+import (
+	"encoding/json"
+)
+
+// NewNativeHostCaller creates a HostCaller in the native target, instead
+// of the wasi one. Useful for tests.
+func NewNativeHostCaller(mockVR VerificationResponse, mockDigest string, mockListIPs []string) HostCaller {
+	return nativeHostCaller{
+		mockVerificationResponse: mockVR,
+		mockDigest:               mockDigest,
+		mockListIPs:              mockListIPs,
+	}
+}
+
+// nativeHostCaller is a HostCaller on the native target. Used as reference
+// implementation, and for type checking
+type nativeHostCaller struct {
+	mockVerificationResponse VerificationResponse
+	mockDigest               string
+	mockListIPs              []string
+}
+
+func (n nativeHostCaller) GetOCIManifest(image string) (response string, err error) {
+	return n.mockDigest, nil
+}
+
+func (n nativeHostCaller) LookupHost(string) ([]string, error) {
+	return n.mockListIPs, nil
+}
+
+func (n nativeHostCaller) VerifyPubKeys(image string, pubKeys []string, annotations map[string]string) (vr VerificationResponse, err error) {
+	// failsafe return response
+	vr = VerificationResponse{
+		IsTrusted: false,
+		Digest:    "",
+	}
+
+	// build request
+	request := sigstorePubKeysVerify{
+		Image:       image,
+		PubKeys:     pubKeys,
+		Annotations: annotations,
+	}
+	var serializedRequest []byte
+	if serializedRequest, err = json.Marshal(request); err != nil {
+		return vr, err
+	}
+
+	// here we would do host callback with serializedRequest
+	_ = serializedRequest // we don't use the serialized request
+	return n.mockVerificationResponse, nil
+}
+
+func (n nativeHostCaller) VerifyKeyless(image string, keyless []KeylessInfo, annotations map[string]string) (vr VerificationResponse, err error) {
+	// failsafe return response
+	vr = VerificationResponse{
+		IsTrusted: false,
+		Digest:    "",
+	}
+
+	// build request
+	request := sigstoreKeylessVerify{
+		Image:       image,
+		Keyless:     keyless,
+		Annotations: annotations,
+	}
+	var serializedRequest []byte
+	if serializedRequest, err = json.Marshal(request); err != nil {
+		return vr, err
+	}
+
+	// here we would do host callback with serializedRequest
+	_ = serializedRequest // we don't use the serialized request
+	return n.mockVerificationResponse, nil
+}

--- a/host_capabilities/hostcaller_wasi.go
+++ b/host_capabilities/hostcaller_wasi.go
@@ -21,7 +21,7 @@ func NewWASIHostCaller() HostCaller {
 type wasiHostCaller struct{}
 
 func (wasiHostCaller) GetOCIManifest(image string) (digest string, err error) {
-	// build request, e.g: `{"ghcr.io/kubewarden/policies/pod-privileged:v0.1.10"}`
+	// build request payload, e.g: `"ghcr.io/kubewarden/policies/pod-privileged:v0.1.10"`
 	request := make([]byte, 0)
 	if request, err = sjson.SetBytes(request, "", []byte(image)); err != nil {
 		return "", err

--- a/host_capabilities/hostcaller_wasi.go
+++ b/host_capabilities/hostcaller_wasi.go
@@ -1,0 +1,176 @@
+// +build wasi
+
+// note well: we have to use the tinygo wasi target, because the wasm one is
+// meant to be used inside of the browser
+
+package host_capabilities
+
+import (
+	"fmt"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	wapc "github.com/wapc/wapc-guest-tinygo"
+)
+
+// NewWASIHostCaller creates a HostCaller in the wasi target, that will be used
+// in the wasm-compiled policy.
+func NewWASIHostCaller() HostCaller {
+	return wasiHostCaller{}
+}
+
+type wasiHostCaller struct{}
+
+func (wasiHostCaller) GetOCIManifest(image string) (digest string, err error) {
+	// build request, e.g: `{"ghcr.io/kubewarden/policies/pod-privileged:v0.1.10"}`
+	request := make([]byte, 0)
+	if request, err = sjson.SetBytes(request, "", []byte(image)); err != nil {
+		return "", err
+	}
+
+	// perform host callback
+	response, err := wapc.HostCall("kubewarden", "oci", "manifest_digest", request)
+	if err != nil {
+		return "", err
+	}
+
+	// extract digest from response
+	digest = gjson.GetBytes(response, "").String()
+	return digest, err
+}
+
+func (wasiHostCaller) LookupHost(host string) (listIPs []string, err error) {
+	// build request, e.g: `{"localhost"}`
+	request := make([]byte, 0)
+	if request, err = sjson.SetBytes(request, "", []byte(host)); err != nil {
+		return nil, err
+	}
+
+	// perform host callback
+	response, err := wapc.HostCall("kubewarden", "net", "dns_lookup_host", request)
+	if err != nil {
+		return nil, err
+	}
+
+	// extract listIPs from response
+	result := gjson.GetBytes(response, "")
+	result.ForEach(func(key, value gjson.Result) bool {
+		listIPs = append(listIPs, value.String())
+		println(value.String())
+		return true // keep iterating
+	})
+
+	return listIPs, err
+}
+
+func (wasiHostCaller) VerifyPubKeys(image string, pubKeys []string, annotations map[string]string) (vr VerificationResponse, err error) {
+	// failsafe return response
+	vr = VerificationResponse{
+		IsTrusted: false,
+		Digest:    "",
+	}
+
+	// build request, e.g:
+	// {
+	//   "image": <string>,
+	//   "pub_keys": [
+	//     <string>
+	//   ],
+	//   "annotations": [
+	//     {
+	//       "key": <string>,
+	//       "value": <string>
+	//     },
+	//   ]
+	// }
+	request := make([]byte, 0)
+	if request, err = sjson.SetBytes(request, "image", []byte(image)); err != nil {
+		return vr, err
+	}
+	for _, pubkey := range pubKeys {
+		// append current pubkey:
+		if request, err = sjson.SetBytes(request, "pub_keys.-1", []byte(pubkey)); err != nil {
+			return vr, err
+		}
+	}
+	for k, v := range annotations {
+		// build json object with key value. We don't know if structs passed to sjson.SetBytes() would work
+		// {
+		//    "key": "foo",
+		//    "value": "bar",
+		// }
+		annotation := fmt.Sprint("{\"key\": \"", k, "\",\"value\": \"", v, "\",}")
+		// append the current annotation:
+		if request, err = sjson.SetBytes(request, "annotations.-1", []byte(annotation)); err != nil {
+			return vr, err
+		}
+	}
+
+	// perform callback
+	response, err := wapc.HostCall("kubewarden", "oci", "v1/verify", request)
+	if err != nil {
+		return vr, err
+	} else {
+		vr.IsTrusted = gjson.GetBytes(response, "is_trusted").Bool()
+		vr.Digest = gjson.GetBytes(response, "digest").String()
+		return vr, nil
+	}
+}
+
+func (wasiHostCaller) VerifyKeyless(image string, keyless []KeylessInfo, annotations map[string]string) (vr VerificationResponse, err error) {
+	// failsafe return response
+	vr = VerificationResponse{
+		IsTrusted: false,
+		Digest:    "",
+	}
+
+	// build request, e.g:
+	// {
+	//   "image": <string>,
+	//   "keyless": [
+	//    {
+	//      "issuer": <string>,
+	//      "subject": <string>,
+	//    }
+	// 	 ],
+	//   "annotations": [
+	//     {
+	//       "key": <string>,
+	//       "value": <string>
+	//     },
+	//   ]
+	// }
+	request := make([]byte, 0)
+	if request, err = sjson.SetBytes(request, "image", []byte(image)); err != nil {
+		return vr, err
+	}
+	for _, v := range keyless {
+		// build current keyless issuerSubject tuple:
+		issuerSubject := fmt.Sprint("{\"issuer\": \"", v.Issuer, "\",\"subject\": \"", v.Subject, "\",}")
+		// append current keyless tuple:
+		if request, err = sjson.SetBytes(request, "keyless.-1", []byte(issuerSubject)); err != nil {
+			return vr, err
+		}
+	}
+	for k, v := range annotations {
+		// build json object with key value. We don't know if structs passed to sjson.SetBytes() would work
+		// {
+		//    "key": "foo",
+		//    "value": "bar",
+		// }
+		annotation := fmt.Sprint("{\"key\": \"", k, "\",\"value\": \"", v, "\",}")
+		// append the current annotation:
+		if request, err = sjson.SetBytes(request, "annotations.-1", []byte(annotation)); err != nil {
+			return vr, err
+		}
+	}
+
+	// perform callback
+	response, err := wapc.HostCall("kubewarden", "oci", "v1/verify", request)
+	if err != nil {
+		return vr, err
+	} else {
+		vr.IsTrusted = gjson.GetBytes(response, "is_trusted").Bool()
+		vr.Digest = gjson.GetBytes(response, "digest").String()
+		return vr, nil
+	}
+}


### PR DESCRIPTION
This package specifies the HostCaller interface, and provides a native
and a wasm hostcaller that implement them.

## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/policy-sdk-go/issues/22

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

Did minimum tests by importing the new package and calling it from a go policy. (used `export GOFLAGS="-mod=mod"`, and a `replace github.com/kubewarden/policy-sdk-go v0.1.2 => ../policy-sdk-go`).

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
