### PR TITLE
fix!: Update testing helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.15'
+          go-version: '1.17'
       - run: make test

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/mailru/easyjson v0.7.7
 	github.com/wapc/wapc-guest-tinygo v0.3.1
 )
+
+require github.com/josharian/intern v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubewarden/policy-sdk-go
 
-go 1.15
+go 1.17
 
 require (
 	github.com/mailru/easyjson v0.7.7

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -1,46 +1,36 @@
 package testing
 
 import (
-	"encoding/json"
-	"io/ioutil"
+	"os"
+
+	kubewarden_protocol "github.com/kubewarden/policy-sdk-go/protocol"
+	"github.com/mailru/easyjson"
 )
-
-// ValidationRequest describes the payload given to the `validate` function
-type ValidationRequest struct {
-	Request  *json.RawMessage `json:"request"`
-	Settings interface{}      `json:"settings"`
-}
-
-// ValidationRequest describes the response returned by the `validate` function
-type ValidationResponse struct {
-	Accepted bool   `json:"accepted"`
-	Message  string `json:"message,omitempty"`
-	Code     uint64 `json:"code,omitempty"`
-}
 
 // BuildValidationRequest creates the payload for the invocation of the `validate`
 // function.
 // * `req_fixture`: path to the json file with a recorded requst to evaluate
 // * `settings`: instance of policy settings. Must be serializable to JSON
-func BuildValidationRequest(req_fixture string, settings interface{}) ([]byte, error) {
-	requestRaw, err := ioutil.ReadFile(req_fixture)
+func BuildValidationRequest(req_fixture string, settings easyjson.MarshalerUnmarshaler) ([]byte, error) {
+	kubeAdmissionReqRaw, err := os.ReadFile(req_fixture)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
-	request := json.RawMessage(requestRaw)
-
-	validation_request := ValidationRequest{
-		Request:  &request,
-		Settings: settings,
+	kubeAdmissionReq := kubewarden_protocol.KubernetesAdmissionRequest{}
+	if err := easyjson.Unmarshal(kubeAdmissionReqRaw, &kubeAdmissionReq); err != nil {
+		return nil, err
 	}
 
-	return json.Marshal(validation_request)
-}
+	settingsRaw, err := easyjson.Marshal(settings)
+	if err != nil {
+		return nil, err
+	}
 
-// SettingsValidationResponse describes the response returned by the
-// `validate_settings` function
-type SettingsValidationResponse struct {
-	Valid   bool   `json:"valid"`
-	Message string `json:"message,omitempty"`
+	validationRequest := kubewarden_protocol.ValidationRequest{
+		Request:  kubeAdmissionReq,
+		Settings: settingsRaw,
+	}
+
+	return easyjson.Marshal(validationRequest)
 }


### PR DESCRIPTION
The testing package used to contain some helper methods and types that could be used inside of policy unit tests.

The module defined objects that are now defined inside of the `protocol` package thanks to us leveraging easyjson.

The `testing` code has been updated to:
  * Remove types that are now declared inside of the `protocol` package
  * Update the functions to make use of the new types used by policies

This is a breaking API change that is going to break old policies unit tests.
