### PR TITLE
update docs and small fix

### DIFF
--- a/host_capabilities/host.go
+++ b/host_capabilities/host.go
@@ -22,10 +22,10 @@ type WapcClient interface {
 	HostCall(binding, namespace, operation string, payload []byte) (response []byte, err error)
 }
 
-// GetOCIManifest computes the digest of the OCI object referenced by image
+// GetOCIManifestDigest computes the digest of the OCI object referenced by image
 // Arguments:
 // * image: image to be verified (e.g.: `registry.testing.lan/busybox:1.0.0`)
-func (h *Host) GetOCIManifest(image string) (string, error) {
+func (h *Host) GetOCIManifestDigest(image string) (string, error) {
 	// build request payload, e.g: `"ghcr.io/kubewarden/policies/pod-privileged:v0.1.10"`
 	payload, err := json.Marshal(image)
 	if err != nil {


### PR DESCRIPTION
Big changes to the README:

* Mention the two ways to write validation policies
* Add section about mutating policies
* Add section about host capabilities

Also a minor refactoring to the host capabilities functions:

* Rename GetOCIManifest to GetOCIManifestDigest, this avoid confusion about what is actually returned.

This renaming breaks the API, but this is not a big deal because we haven't yet tagged a release with this function.
