### PR TITLE
Add ExtractPodSpecFromObject

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,11 @@ require (
 	github.com/wapc/wapc-guest-tinygo v0.3.3
 )
 
-require github.com/josharian/intern v1.0.0 // indirect
+require github.com/go-openapi/strfmt v0.0.0-00010101000000-000000000000 // indirect
+
+require (
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/kubewarden/k8s-objects v1.24.0-kw3
+)
+
+replace github.com/go-openapi/strfmt => github.com/kubewarden/strfmt v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/kubewarden/k8s-objects v1.24.0-kw3 h1:cRi2A5iESlZHqokXY0QXW6LdQaDXyLzTjja4V3Y2luo=
+github.com/kubewarden/k8s-objects v1.24.0-kw3/go.mod h1:IuIHLG1JtxjC1JnY7SyEEA9MukCh/FACcwpzaBjgdLQ=
+github.com/kubewarden/strfmt v0.1.0 h1:rMYG+48QSckzdVhFMikgGDUJODvvMHpudraWfw0jgvc=
+github.com/kubewarden/strfmt v0.1.0/go.mod h1:G83H1PTqI8ewtrTonL/uMbx1pJooaKSbAoIpoKqT5KA=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/wapc/wapc-guest-tinygo v0.3.1 h1:ecmT4W+ynsNvRvLolPw2rQRafCAoLMh7L/u6ZxVSWXU=
-github.com/wapc/wapc-guest-tinygo v0.3.1/go.mod h1:Jssn+ovE+Y2oueUgVeLyGZf2ipUPngVnWTNPM8zmhn0=
-github.com/wapc/wapc-guest-tinygo v0.3.2 h1:b9zkLL+44dxL8MWjZmdG6XAcO6ITK5Xzgok0eKzu/vY=
-github.com/wapc/wapc-guest-tinygo v0.3.2/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=
 github.com/wapc/wapc-guest-tinygo v0.3.3 h1:jLebiwjVSHLGnS+BRabQ6+XOV7oihVWAc05Hf1SbeR0=
 github.com/wapc/wapc-guest-tinygo v0.3.3/go.mod h1:mzM3CnsdSYktfPkaBdZ8v88ZlfUDEy5Jh5XBOV3fYcw=

--- a/kubewarden.go
+++ b/kubewarden.go
@@ -4,6 +4,11 @@
 package sdk
 
 import (
+	"errors"
+
+	appsv1 "github.com/kubewarden/k8s-objects/api/apps/v1"
+	batchv1 "github.com/kubewarden/k8s-objects/api/batch/v1"
+	corev1 "github.com/kubewarden/k8s-objects/api/core/v1"
 	"github.com/kubewarden/policy-sdk-go/protocol"
 	"github.com/mailru/easyjson"
 )
@@ -65,6 +70,73 @@ func MutateRequest(newObject easyjson.Marshaler) ([]byte, error) {
 	return easyjson.Marshal(response)
 }
 
+// Update the pod sec from the resource defined in the original object and
+// create an acceptance response.
+// * `validation_request` - the original admission request
+// * `pod_spec` - new PodSpec to be set in the response
+func MutatePodSpecFromRequest(validationRequest protocol.ValidationRequest, podSepc corev1.PodSpec) ([]byte, error) {
+	switch validationRequest.Request.Kind.Kind {
+	case "apps.v1.Deployment":
+		deployment := appsv1.Deployment{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &deployment); err != nil {
+			return nil, err
+		}
+		deployment.Spec.Template.Spec = &podSepc
+		return MutateRequest(deployment)
+	case "apps.v1.ReplicaSet":
+		replicaset := appsv1.ReplicaSet{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &replicaset); err != nil {
+			return nil, err
+		}
+		replicaset.Spec.Template.Spec = &podSepc
+		return MutateRequest(replicaset)
+	case "apps.v1.StatefulSet":
+		statefulset := appsv1.StatefulSet{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &statefulset); err != nil {
+			return nil, err
+		}
+		statefulset.Spec.Template.Spec = &podSepc
+		return MutateRequest(statefulset)
+	case "apps.v1.DaemonSet":
+		daemonset := appsv1.DaemonSet{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &daemonset); err != nil {
+			return nil, err
+		}
+		daemonset.Spec.Template.Spec = &podSepc
+		return MutateRequest(daemonset)
+	case "v1.ReplicationController":
+		replicationController := corev1.ReplicationController{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &replicationController); err != nil {
+			return nil, err
+		}
+		replicationController.Spec.Template.Spec = &podSepc
+		return MutateRequest(replicationController)
+	case "batch.v1.CronJob":
+		cronjob := batchv1.CronJob{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &cronjob); err != nil {
+			return nil, err
+		}
+		cronjob.Spec.JobTemplate.Spec.Template.Spec = &podSepc
+		return MutateRequest(cronjob)
+	case "batch.v1.Job":
+		job := batchv1.Job{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &job); err != nil {
+			return nil, err
+		}
+		job.Spec.Template.Spec = &podSepc
+		return MutateRequest(job)
+	case "v1.Pod":
+		pod := corev1.Pod{}
+		if err := easyjson.Unmarshal(validationRequest.Request.Object, &pod); err != nil {
+			return nil, err
+		}
+		pod.Spec = &podSepc
+		return MutateRequest(pod)
+	default:
+		return RejectRequest("Object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod", NoCode)
+	}
+}
+
 // AcceptSettings can be used inside of the `validate_settings` function to
 // mark the user provided settings as valid
 func AcceptSettings() ([]byte, error) {
@@ -87,4 +159,67 @@ func RejectSettings(message Message) ([]byte, error) {
 		response.Message = &msg
 	}
 	return easyjson.Marshal(response)
+}
+
+// Extract PodSpec from high level objects. This method can be used to evaluate
+// high level objects instead of just Pods. For example, it can be used to
+// reject Deployments or StatefulSets that violate a policy instead of the Pods
+// created by them. Objects supported are: Deployment, ReplicaSet, StatefulSet,
+// DaemonSet, ReplicationController, Job, CronJob, Pod It returns an error if
+// the object is not one of those. If it is a supported object it returns the
+// PodSpec if present, otherwise returns None.
+// * `object`: the request to validate
+func ExtractPodSpecFromObject(object protocol.ValidationRequest) (corev1.PodSpec, error) {
+	switch object.Request.Kind.Kind {
+	case "apps.v1.Deployment":
+		deployment := appsv1.Deployment{}
+		if err := easyjson.Unmarshal(object.Request.Object, &deployment); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *deployment.Spec.Template.Spec, nil
+	case "apps.v1.ReplicaSet":
+		replicaset := appsv1.ReplicaSet{}
+		if err := easyjson.Unmarshal(object.Request.Object, &replicaset); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *replicaset.Spec.Template.Spec, nil
+	case "apps.v1.StatefulSet":
+		statefulset := appsv1.StatefulSet{}
+		if err := easyjson.Unmarshal(object.Request.Object, &statefulset); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *statefulset.Spec.Template.Spec, nil
+	case "apps.v1.DaemonSet":
+		daemonset := appsv1.DaemonSet{}
+		if err := easyjson.Unmarshal(object.Request.Object, &daemonset); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *daemonset.Spec.Template.Spec, nil
+	case "v1.ReplicationController":
+		replicationController := corev1.ReplicationController{}
+		if err := easyjson.Unmarshal(object.Request.Object, &replicationController); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *replicationController.Spec.Template.Spec, nil
+	case "batch.v1.CronJob":
+		cronjob := batchv1.CronJob{}
+		if err := easyjson.Unmarshal(object.Request.Object, &cronjob); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *cronjob.Spec.JobTemplate.Spec.Template.Spec, nil
+	case "batch.v1.Job":
+		job := batchv1.Job{}
+		if err := easyjson.Unmarshal(object.Request.Object, &job); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *job.Spec.Template.Spec, nil
+	case "v1.Pod":
+		pod := corev1.Pod{}
+		if err := easyjson.Unmarshal(object.Request.Object, &pod); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *pod.Spec, nil
+	default:
+		return corev1.PodSpec{}, errors.New("object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod")
+	}
 }

--- a/kubewarden.go
+++ b/kubewarden.go
@@ -167,7 +167,7 @@ func RejectSettings(message Message) ([]byte, error) {
 // created by them. Objects supported are: Deployment, ReplicaSet, StatefulSet,
 // DaemonSet, ReplicationController, Job, CronJob, Pod It returns an error if
 // the object is not one of those. If it is a supported object it returns the
-// PodSpec if present, otherwise returns None.
+// PodSpec if present, otherwise returns an empty PodSpec.
 // * `object`: the request to validate
 func ExtractPodSpecFromObject(object protocol.ValidationRequest) (corev1.PodSpec, error) {
 	switch object.Request.Kind.Kind {

--- a/kubewarden.go
+++ b/kubewarden.go
@@ -70,7 +70,7 @@ func MutateRequest(newObject easyjson.Marshaler) ([]byte, error) {
 	return easyjson.Marshal(response)
 }
 
-// Update the pod sec from the resource defined in the original object and
+// Update the pod spec from the resource defined in the original object and
 // create an acceptance response.
 // * `validation_request` - the original admission request
 // * `pod_spec` - new PodSpec to be set in the response

--- a/kubewarden_test.go
+++ b/kubewarden_test.go
@@ -1,0 +1,339 @@
+package sdk
+
+import (
+	"testing"
+
+	appsv1 "github.com/kubewarden/k8s-objects/api/apps/v1"
+	batchv1 "github.com/kubewarden/k8s-objects/api/batch/v1"
+	corev1 "github.com/kubewarden/k8s-objects/api/core/v1"
+	"github.com/kubewarden/policy-sdk-go/protocol"
+	"github.com/mailru/easyjson"
+	"github.com/mailru/easyjson/jwriter"
+)
+
+func CreateValidationRequest(object easyjson.Marshaler, kind string) (protocol.ValidationRequest, error) {
+	w := jwriter.Writer{}
+	object.MarshalEasyJSON(&w)
+	value, err := w.BuildBytes()
+	if err != nil {
+		return protocol.ValidationRequest{}, err
+	}
+
+	validationRequest := protocol.ValidationRequest{
+		Settings: easyjson.RawMessage{},
+		Request: protocol.KubernetesAdmissionRequest{
+			Kind: protocol.GroupVersionKind{
+				Kind: kind,
+			},
+			Object: value,
+		},
+	}
+
+	return validationRequest, nil
+}
+
+func CheckIfAutomountServiceAccountTokenIsTrue(t *testing.T, rawResponse []byte) protocol.ValidationResponse {
+	response := protocol.ValidationResponse{}
+	if err := easyjson.Unmarshal(rawResponse, &response); err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if !response.Accepted {
+		t.Fatalf("Response not accepted")
+	}
+
+	if len(response.MutatedObject.(map[string]interface{})) == 0 {
+		t.Fatalf("Request should be mutated")
+	}
+
+	return response
+}
+
+func TestMutatePodSpecFromRequestWithDeployment(t *testing.T) {
+	deployment := appsv1.Deployment{
+		Spec: &appsv1.DeploymentSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: false,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(deployment, "apps.v1.Deployment")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithReplicaset(t *testing.T) {
+	replicaset := appsv1.ReplicaSet{
+		Spec: &appsv1.ReplicaSetSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: false,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(replicaset, "apps.v1.ReplicaSet")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithStatefulset(t *testing.T) {
+	statefulset := appsv1.StatefulSet{
+		Spec: &appsv1.StatefulSetSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: false,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(statefulset, "apps.v1.StatefulSet")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithDaemonset(t *testing.T) {
+	daemonset := appsv1.DaemonSet{
+		Spec: &appsv1.DaemonSetSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: false,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(daemonset, "apps.v1.DaemonSet")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithReplicationcontroller(t *testing.T) {
+	replicationController := corev1.ReplicationController{
+		Spec: &corev1.ReplicationControllerSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: false,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(replicationController, "v1.ReplicationController")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithCronjob(t *testing.T) {
+	cronjob := batchv1.CronJob{
+		Spec: &batchv1.CronJobSpec{
+			JobTemplate: &batchv1.JobTemplateSpec{
+				Spec: &batchv1.JobSpec{
+					Template: &corev1.PodTemplateSpec{
+						Spec: &corev1.PodSpec{
+							AutomountServiceAccountToken: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(cronjob, "batch.v1.CronJob")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["jobTemplate"].(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithJob(t *testing.T) {
+	job := batchv1.Job{
+		Spec: &batchv1.JobSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: false,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(job, "batch.v1.Job")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithPod(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: &corev1.PodSpec{
+			AutomountServiceAccountToken: false,
+		},
+	}
+
+	validationRequest, err := CreateValidationRequest(pod, "v1.Pod")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := CheckIfAutomountServiceAccountTokenIsTrue(t, rawResponse)
+
+	if response.MutatedObject.(map[string]interface{})["spec"].(map[string]interface{})["automountServiceAccountToken"].(bool) != true {
+		t.Fatalf("Request not mutated")
+	}
+}
+
+func TestMutatePodSpecFromRequestWithInvalidResourceType(t *testing.T) {
+	pod := &corev1.Pod{}
+
+	validationRequest, err := CreateValidationRequest(pod, "InvalidType")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := protocol.ValidationResponse{}
+	if err := easyjson.Unmarshal(rawResponse, &response); err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if response.Accepted {
+		t.Fatalf("Response accepted")
+	}
+
+	errorMessage := response.Message
+	expectedErrorMessage := "Object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod"
+	if *errorMessage != expectedErrorMessage {
+		t.Fatalf("Different error occurred")
+	}
+}

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -1,8 +1,12 @@
 package testing
 
 import (
+	"errors"
 	"os"
 
+	appsv1 "github.com/kubewarden/k8s-objects/api/apps/v1"
+	batchv1 "github.com/kubewarden/k8s-objects/api/batch/v1"
+	corev1 "github.com/kubewarden/k8s-objects/api/core/v1"
 	kubewarden_protocol "github.com/kubewarden/policy-sdk-go/protocol"
 	"github.com/mailru/easyjson"
 )
@@ -60,4 +64,63 @@ func BuildValidationRequest(object, settings easyjson.Marshaler) ([]byte, error)
 	}
 
 	return easyjson.Marshal(validationRequest)
+}
+
+// Extract PodSpec from high level objects. This method can be used to evaluate high level objects instead of just Pods.
+// For example, it can be used to reject Deployments or StatefulSets that violate a policy instead of the Pods created by them.
+// Objects supported are: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod
+// It returns an error if the object is not one of those. If it is a supported object it returns the PodSpec if present, otherwise returns None.
+func ExtractPodSpecFromObject(object kubewarden_protocol.ValidationRequest) (corev1.PodSpec, error) {
+	switch object.Request.Kind.Kind {
+	case "Deployment":
+		deployment := &appsv1.Deployment{}
+		if err := easyjson.Unmarshal(object.Request.Object, deployment); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *deployment.Spec.Template.Spec, nil
+	case "ReplicaSet":
+		replicaset := &appsv1.ReplicaSet{}
+		if err := easyjson.Unmarshal(object.Request.Object, replicaset); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *replicaset.Spec.Template.Spec, nil
+	case "StatefulSet":
+		statefulset := &appsv1.StatefulSet{}
+		if err := easyjson.Unmarshal(object.Request.Object, statefulset); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *statefulset.Spec.Template.Spec, nil
+	case "DaemonSet":
+		daemonset := &appsv1.DaemonSet{}
+		if err := easyjson.Unmarshal(object.Request.Object, daemonset); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *daemonset.Spec.Template.Spec, nil
+	case "ReplicationController":
+		replication_controller := &corev1.ReplicationController{}
+		if err := easyjson.Unmarshal(object.Request.Object, replication_controller); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *replication_controller.Spec.Template.Spec, nil
+	case "CronJob":
+		cronjob := &batchv1.CronJob{}
+		if err := easyjson.Unmarshal(object.Request.Object, cronjob); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *cronjob.Spec.JobTemplate.Spec.Template.Spec, nil
+	case "Job":
+		job := &batchv1.Job{}
+		if err := easyjson.Unmarshal(object.Request.Object, job); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *job.Spec.Template.Spec, nil
+	case "Pod":
+		pod := &corev1.Pod{}
+		if err := easyjson.Unmarshal(object.Request.Object, pod); err != nil {
+			return corev1.PodSpec{}, err
+		}
+		return *pod.Spec, nil
+	default:
+		return corev1.PodSpec{}, errors.New("object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod")
+	}
 }

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -1,12 +1,8 @@
 package testing
 
 import (
-	"errors"
 	"os"
 
-	appsv1 "github.com/kubewarden/k8s-objects/api/apps/v1"
-	batchv1 "github.com/kubewarden/k8s-objects/api/batch/v1"
-	corev1 "github.com/kubewarden/k8s-objects/api/core/v1"
 	kubewarden_protocol "github.com/kubewarden/policy-sdk-go/protocol"
 	"github.com/mailru/easyjson"
 )
@@ -64,63 +60,4 @@ func BuildValidationRequest(object, settings easyjson.Marshaler) ([]byte, error)
 	}
 
 	return easyjson.Marshal(validationRequest)
-}
-
-// Extract PodSpec from high level objects. This method can be used to evaluate high level objects instead of just Pods.
-// For example, it can be used to reject Deployments or StatefulSets that violate a policy instead of the Pods created by them.
-// Objects supported are: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod
-// It returns an error if the object is not one of those. If it is a supported object it returns the PodSpec if present, otherwise returns None.
-func ExtractPodSpecFromObject(object kubewarden_protocol.ValidationRequest) (corev1.PodSpec, error) {
-	switch object.Request.Kind.Kind {
-	case "Deployment":
-		deployment := &appsv1.Deployment{}
-		if err := easyjson.Unmarshal(object.Request.Object, deployment); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *deployment.Spec.Template.Spec, nil
-	case "ReplicaSet":
-		replicaset := &appsv1.ReplicaSet{}
-		if err := easyjson.Unmarshal(object.Request.Object, replicaset); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *replicaset.Spec.Template.Spec, nil
-	case "StatefulSet":
-		statefulset := &appsv1.StatefulSet{}
-		if err := easyjson.Unmarshal(object.Request.Object, statefulset); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *statefulset.Spec.Template.Spec, nil
-	case "DaemonSet":
-		daemonset := &appsv1.DaemonSet{}
-		if err := easyjson.Unmarshal(object.Request.Object, daemonset); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *daemonset.Spec.Template.Spec, nil
-	case "ReplicationController":
-		replication_controller := &corev1.ReplicationController{}
-		if err := easyjson.Unmarshal(object.Request.Object, replication_controller); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *replication_controller.Spec.Template.Spec, nil
-	case "CronJob":
-		cronjob := &batchv1.CronJob{}
-		if err := easyjson.Unmarshal(object.Request.Object, cronjob); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *cronjob.Spec.JobTemplate.Spec.Template.Spec, nil
-	case "Job":
-		job := &batchv1.Job{}
-		if err := easyjson.Unmarshal(object.Request.Object, job); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *job.Spec.Template.Spec, nil
-	case "Pod":
-		pod := &corev1.Pod{}
-		if err := easyjson.Unmarshal(object.Request.Object, pod); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *pod.Spec, nil
-	default:
-		return corev1.PodSpec{}, errors.New("object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod")
-	}
 }


### PR DESCRIPTION
## Description

New method for retrieving a PodSpec given you pass a high level object. Objects supported are: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod.

This simplifies the evaluation of high level objects. A policy author just need to call this new method and evaluate the PodSpec returned. With this change pod-privileged-policy will reject high level objects (e.g Deployments) instead of allowing them and later rejects the pods

This is to map the Rust feature according to [this issue](https://github.com/kubewarden/kubewarden-controller/issues/392).

Fix #36

## Test

## Additional Information

### Tradeoff

### Potential improvement
