### PR TITLE
Update k8s objects to v1.24.0-kw4.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require github.com/go-openapi/strfmt v0.21.3 // indirect
 
 require (
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/kubewarden/k8s-objects v1.24.0-kw3
+	github.com/kubewarden/k8s-objects v1.24.0-kw4
 )
 
 replace github.com/go-openapi/strfmt => github.com/kubewarden/strfmt v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/kubewarden/k8s-objects v1.24.0-kw3 h1:cRi2A5iESlZHqokXY0QXW6LdQaDXyLzTjja4V3Y2luo=
-github.com/kubewarden/k8s-objects v1.24.0-kw3/go.mod h1:IuIHLG1JtxjC1JnY7SyEEA9MukCh/FACcwpzaBjgdLQ=
+github.com/kubewarden/k8s-objects v1.24.0-kw4 h1:/XAEdK8uHUz+asM/PgUs1T4vgCN7d+tiDDb5azMOimo=
+github.com/kubewarden/k8s-objects v1.24.0-kw4/go.mod h1:0d8vhSnO2G4bwo58G9ncQYhsgBggGzgh+V0Wqc3CLe8=
 github.com/kubewarden/strfmt v0.1.2 h1:S0YUVkPeyUMikz8QssbMzfd1MC5K8ZqxLI2zfF8euMs=
 github.com/kubewarden/strfmt v0.1.2/go.mod h1:sqLlis8qlm4A4pnZsRyRjNxyH86fiM+7Ee7bO+uJk94=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/go-openapi/strfmt
 # github.com/josharian/intern v1.0.0
 ## explicit; go 1.5
 github.com/josharian/intern
-# github.com/kubewarden/k8s-objects v1.24.0-kw3
+# github.com/kubewarden/k8s-objects v1.24.0-kw4
 ## explicit; go 1.17
 github.com/kubewarden/k8s-objects/api/apps/v1
 github.com/kubewarden/k8s-objects/api/batch/v1


### PR DESCRIPTION
## Description

Update the Golang SDK to use the latest version of the k8s-object module. The new version fix the invalid strfmt version causing issue in the policies build.


Related to https://github.com/kubewarden/safe-labels-policy/pull/16#issuecomment-1469960194