### PR TITLE
fix: use the correct waPC function to list k8s resources

### DIFF
--- a/pkg/capabilities/kubernetes/kubernetes.go
+++ b/pkg/capabilities/kubernetes/kubernetes.go
@@ -34,7 +34,7 @@ func ListResources(h *cap.Host, req ListAllResourcesRequest) ([]byte, error) {
 	}
 
 	// perform callback
-	responsePayload, err := h.Client.HostCall("kubewarden", "kubernetes", "list_all_resources", payload)
+	responsePayload, err := h.Client.HostCall("kubewarden", "kubernetes", "list_resources_all", payload)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/capabilities/kubernetes/kubernetes_test.go
+++ b/pkg/capabilities/kubernetes/kubernetes_test.go
@@ -46,7 +46,7 @@ func TestKubernetesListResources(t *testing.T) {
 
 	m.
 		EXPECT().
-		HostCall("kubewarden", "kubernetes", "list_all_resources", []byte(expectedInputPayload)).
+		HostCall("kubewarden", "kubernetes", "list_resources_all", []byte(expectedInputPayload)).
 		Return([]byte{}, nil).
 		Times(1)
 


### PR DESCRIPTION
The Go SDK invoked the wrong host function when listing all the Kubernetes resources.

The issue has been reported by @brunorene
