### PR TITLE
fix: wrong Kubernetes kinds.

### DIFF
--- a/kubewarden.go
+++ b/kubewarden.go
@@ -76,56 +76,56 @@ func MutateRequest(newObject interface{}) ([]byte, error) {
 // * `pod_spec` - new PodSpec to be set in the response
 func MutatePodSpecFromRequest(validationRequest protocol.ValidationRequest, podSepc corev1.PodSpec) ([]byte, error) {
 	switch validationRequest.Request.Kind.Kind {
-	case "apps.v1.Deployment":
+	case "Deployment":
 		deployment := appsv1.Deployment{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &deployment); err != nil {
 			return nil, err
 		}
 		deployment.Spec.Template.Spec = &podSepc
 		return MutateRequest(deployment)
-	case "apps.v1.ReplicaSet":
+	case "ReplicaSet":
 		replicaset := appsv1.ReplicaSet{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &replicaset); err != nil {
 			return nil, err
 		}
 		replicaset.Spec.Template.Spec = &podSepc
 		return MutateRequest(replicaset)
-	case "apps.v1.StatefulSet":
+	case "StatefulSet":
 		statefulset := appsv1.StatefulSet{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &statefulset); err != nil {
 			return nil, err
 		}
 		statefulset.Spec.Template.Spec = &podSepc
 		return MutateRequest(statefulset)
-	case "apps.v1.DaemonSet":
+	case "DaemonSet":
 		daemonset := appsv1.DaemonSet{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &daemonset); err != nil {
 			return nil, err
 		}
 		daemonset.Spec.Template.Spec = &podSepc
 		return MutateRequest(daemonset)
-	case "v1.ReplicationController":
+	case "ReplicationController":
 		replicationController := corev1.ReplicationController{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &replicationController); err != nil {
 			return nil, err
 		}
 		replicationController.Spec.Template.Spec = &podSepc
 		return MutateRequest(replicationController)
-	case "batch.v1.CronJob":
+	case "CronJob":
 		cronjob := batchv1.CronJob{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &cronjob); err != nil {
 			return nil, err
 		}
 		cronjob.Spec.JobTemplate.Spec.Template.Spec = &podSepc
 		return MutateRequest(cronjob)
-	case "batch.v1.Job":
+	case "Job":
 		job := batchv1.Job{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &job); err != nil {
 			return nil, err
 		}
 		job.Spec.Template.Spec = &podSepc
 		return MutateRequest(job)
-	case "v1.Pod":
+	case "Pod":
 		pod := corev1.Pod{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &pod); err != nil {
 			return nil, err
@@ -171,49 +171,49 @@ func RejectSettings(message Message) ([]byte, error) {
 // * `object`: the request to validate
 func ExtractPodSpecFromObject(object protocol.ValidationRequest) (corev1.PodSpec, error) {
 	switch object.Request.Kind.Kind {
-	case "apps.v1.Deployment":
+	case "Deployment":
 		deployment := appsv1.Deployment{}
 		if err := json.Unmarshal(object.Request.Object, &deployment); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *deployment.Spec.Template.Spec, nil
-	case "apps.v1.ReplicaSet":
+	case "ReplicaSet":
 		replicaset := appsv1.ReplicaSet{}
 		if err := json.Unmarshal(object.Request.Object, &replicaset); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *replicaset.Spec.Template.Spec, nil
-	case "apps.v1.StatefulSet":
+	case "StatefulSet":
 		statefulset := appsv1.StatefulSet{}
 		if err := json.Unmarshal(object.Request.Object, &statefulset); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *statefulset.Spec.Template.Spec, nil
-	case "apps.v1.DaemonSet":
+	case "DaemonSet":
 		daemonset := appsv1.DaemonSet{}
 		if err := json.Unmarshal(object.Request.Object, &daemonset); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *daemonset.Spec.Template.Spec, nil
-	case "v1.ReplicationController":
+	case "ReplicationController":
 		replicationController := corev1.ReplicationController{}
 		if err := json.Unmarshal(object.Request.Object, &replicationController); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *replicationController.Spec.Template.Spec, nil
-	case "batch.v1.CronJob":
+	case "CronJob":
 		cronjob := batchv1.CronJob{}
 		if err := json.Unmarshal(object.Request.Object, &cronjob); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *cronjob.Spec.JobTemplate.Spec.Template.Spec, nil
-	case "batch.v1.Job":
+	case "Job":
 		job := batchv1.Job{}
 		if err := json.Unmarshal(object.Request.Object, &job); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *job.Spec.Template.Spec, nil
-	case "v1.Pod":
+	case "Pod":
 		pod := corev1.Pod{}
 		if err := json.Unmarshal(object.Request.Object, &pod); err != nil {
 			return corev1.PodSpec{}, err

--- a/kubewarden_test.go
+++ b/kubewarden_test.go
@@ -71,7 +71,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 
 	for description, testCase := range map[string]mutatePodSpecFromRequestTestCase{
 		"WithDeployment": {
-			kind: "apps.v1.Deployment",
+			kind: "Deployment",
 			object: appsv1.Deployment{
 				Spec: &appsv1.DeploymentSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -85,7 +85,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithDeployment,
 		},
 		"WithReplicaset": {
-			kind: "apps.v1.ReplicaSet",
+			kind: "ReplicaSet",
 			object: appsv1.ReplicaSet{
 				Spec: &appsv1.ReplicaSetSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -99,7 +99,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithReplicaset,
 		},
 		"WithStatefulset": {
-			kind: "apps.v1.StatefulSet",
+			kind: "StatefulSet",
 			object: appsv1.StatefulSet{
 				Spec: &appsv1.StatefulSetSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -113,7 +113,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithStatefulset,
 		},
 		"WithDaemonset": {
-			kind: "apps.v1.DaemonSet",
+			kind: "DaemonSet",
 			object: appsv1.DaemonSet{
 				Spec: &appsv1.DaemonSetSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -127,7 +127,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithDaemonset,
 		},
 		"WithReplicationcontroller": {
-			kind: "v1.ReplicationController",
+			kind: "ReplicationController",
 			object: corev1.ReplicationController{
 				Spec: &corev1.ReplicationControllerSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -141,7 +141,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithReplicationcontroller,
 		},
 		"WithCronjob": {
-			kind: "batch.v1.CronJob",
+			kind: "CronJob",
 			object: batchv1.CronJob{
 				Spec: &batchv1.CronJobSpec{
 					JobTemplate: &batchv1.JobTemplateSpec{
@@ -159,7 +159,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithCronjob,
 		},
 		"WithJob": {
-			kind: "batch.v1.Job",
+			kind: "Job",
 			object: batchv1.Job{
 				Spec: &batchv1.JobSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -173,7 +173,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithJob,
 		},
 		"WithPod": {
-			kind: "v1.Pod",
+			kind: "Pod",
 			object: corev1.Pod{
 				Spec: &corev1.PodSpec{
 					AutomountServiceAccountToken: false,


### PR DESCRIPTION
## Description

The SDK is using the wrong kind types to extract and update PodSpec in the different Kubernetes kinds supported. This commit fixes the kind names.