### PR TITLE
fix: make conformant k8s requests

### DIFF
--- a/pkg/capabilities/kubernetes/kubernetes_test.go
+++ b/pkg/capabilities/kubernetes/kubernetes_test.go
@@ -24,12 +24,15 @@ func TestKubernetesListResourcesByNamespace(t *testing.T) {
 		Client: m,
 	}
 
+	labelSelector := "app=nginx"
+	fieldSelector := "status.phase=Running"
+
 	inputRequest := ListResourcesByNamespaceRequest{
 		APIVersion:    "v1",
 		Kind:          "Pod",
 		Namespace:     "default",
-		LabelSelector: "app=nginx",
-		FieldSelector: "status.phase=Running",
+		LabelSelector: &labelSelector,
+		FieldSelector: &fieldSelector,
 	}
 
 	_, err := ListResourcesByNamespace(host, inputRequest)
@@ -54,11 +57,14 @@ func TestKubernetesListResources(t *testing.T) {
 		Client: m,
 	}
 
+	labelSelector := "app=nginx"
+	fieldSelector := "status.phase=Running"
+
 	inputRequest := ListAllResourcesRequest{
 		APIVersion:    "v1",
 		Kind:          "Pod",
-		LabelSelector: "app=nginx",
-		FieldSelector: "status.phase=Running",
+		LabelSelector: &labelSelector,
+		FieldSelector: &fieldSelector,
 	}
 
 	_, err := ListResources(host, inputRequest)

--- a/pkg/capabilities/kubernetes/types.go
+++ b/pkg/capabilities/kubernetes/types.go
@@ -10,10 +10,10 @@ type ListResourcesByNamespaceRequest struct {
 	Namespace string `json:"namespace"`
 	// A selector to restrict the list of returned objects by their labels.
 	// Defaults to everything if omitted
-	LabelSelector string `json:"label_selector"`
+	LabelSelector *string `json:"label_selector,omitempty"`
 	// A selector to restrict the list of returned objects by their fields.
 	// Defaults to everything if omitted
-	FieldSelector string `json:"field_selector"`
+	FieldSelector *string `json:"field_selector,omitempty"`
 }
 
 // Set of parameters used by the `list_all_resources` function
@@ -24,10 +24,10 @@ type ListAllResourcesRequest struct {
 	Kind string `json:"kind"`
 	// A selector to restrict the list of returned objects by their labels.
 	// Defaults to everything if omitted
-	LabelSelector string `json:"label_selector"`
+	LabelSelector *string `json:"label_selector,omitempty"`
 	// A selector to restrict the list of returned objects by their fields.
 	// Defaults to everything if omitted
-	FieldSelector string `json:"field_selector"`
+	FieldSelector *string `json:"field_selector,omitempty"`
 }
 
 // Set of parameters used by the `get_resource` function


### PR DESCRIPTION
The `LabelSelector` and `FieldSelector` should not be defaulted to an empty string, they should rather not be sent at all when unset.

To achieve that, they have to be represented with a pointer.

I noticed this behavior while reusing a session recorded with a Rust context aware policy. That doesn't mean the k8s integration has always been broken with Go policies, but we have not been 100% compliant with our spec.
