### PR TITLE
fix!: allow namespace to be nil in GetResourceRequest type

### DIFF
--- a/pkg/capabilities/kubernetes/kubernetes_test.go
+++ b/pkg/capabilities/kubernetes/kubernetes_test.go
@@ -88,11 +88,11 @@ func TestKubernetesGetResource(t *testing.T) {
 	host := &cap.Host{
 		Client: m,
 	}
-
+	namespace := "default"
 	inputRequest := GetResourceRequest{
 		APIVersion:   "v1",
 		Kind:         "Pod",
-		Namespace:    "default",
+		Namespace:    &namespace,
 		Name:         "nginx",
 		DisableCache: false,
 	}

--- a/pkg/capabilities/kubernetes/types.go
+++ b/pkg/capabilities/kubernetes/types.go
@@ -38,7 +38,7 @@ type GetResourceRequest struct {
 	// The name of the resource
 	Name string `json:"name"`
 	// Namespace scoping the search
-	Namespace string `json:"namespace"`
+	Namespace *string `json:"namespace,omitempty"`
 	// Disable caching of results obtained from Kubernetes API Server
 	// By default query results are cached for 5 seconds, that might cause
 	// stale data to be returned.


### PR DESCRIPTION
## Description

Since the namespace could be null when getting cluster-wide resources, we need to change the GetResourceRequest type accordingly.
The current implementation uses the go empty value for strings (`""`) that causes discrepancy when recording/replaying sessions from/to other languages.

For example, before the fix, a rust policy will record:

```
- type: Exchange
  request: |
    !KubernetesGetResource
    api_version: v1
    kind: Namespace
    name: default
    namespace: null
    disable_cache: false
  response:
    type: Success
    payload: .....
```

A go policy will record this session instead:

```
- type: Exchange
  request: |
    !KubernetesGetResource
    api_version: v1
    kind: Namespace
    name: default
    namespace: ''
    disable_cache: false
  response:
    type: Success
    payload: .....
```

This returns an error when trying to replay the session.


## Test
Existing tests updated 

## Additional Information

### Tradeoff

This is a breaking change, requiring the user to change the current policies.
