### PR TITLE
refactor!: return CertificateVerficationResponse{} in VerifyCert()

### DIFF
--- a/pkg/capabilities/crypto/crypto_test.go
+++ b/pkg/capabilities/crypto/crypto_test.go
@@ -52,7 +52,7 @@ func TestV1IsCertificateTrusted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !res {
+	if !res.Trusted {
 		t.Fatalf("expected trusted image, got untrusted")
 	}
 }


### PR DESCRIPTION
## Description

Relates to https://github.com/kubewarden/cel-policy/issues/15.

`pkg/capabilities/VerifyCert()` returns a `(bool, err)`. In the case that it returns `(false, err)`, the error is not a runtime error but it may contain the reason for the failed certificate verification.

Return a `(CertificateVerficationResponse{},err)` instead, which contains the bool trusted and a reason, or a runtime error.


<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
