### PR TITLE
feat: Export and json-tag fields of manifest.OciImageManifestResponse{}

### DIFF
--- a/pkg/capabilities/oci/manifest/types.go
+++ b/pkg/capabilities/oci/manifest/types.go
@@ -8,30 +8,30 @@ import (
 )
 
 type OciImageManifestResponse struct {
-	image *specs.Manifest
-	index *specs.Index
+	Image *specs.Manifest `json:"image"`
+	Index *specs.Index    `json:"index"`
 }
 
 func (r OciImageManifestResponse) ImageManifest() *specs.Manifest {
-	return r.image
+	return r.Image
 }
 
 func (r OciImageManifestResponse) IndexManifest() *specs.Index {
-	return r.index
+	return r.Index
 }
 
 func (r *OciImageManifestResponse) UnmarshalJSON(b []byte) error {
 	imageManifest := specs.Manifest{}
 	if err := json.Unmarshal(b, &imageManifest); err == nil {
 		if isImageMediaType(imageManifest.MediaType) {
-			r.image = &imageManifest
+			r.Image = &imageManifest
 			return nil
 		}
 	}
 	indexManifest := specs.Index{}
 	if err := json.Unmarshal(b, &indexManifest); err == nil {
 		if isImageIndexMediaType(indexManifest.MediaType) {
-			r.index = &indexManifest
+			r.Index = &indexManifest
 			return nil
 		}
 		return fmt.Errorf("not a valid media type: %s", indexManifest.MediaType)


### PR DESCRIPTION

## Description

Relates to https://github.com/kubewarden/cel-policy/issues/31

Setting the json tags is needed as we marshal this struct in the cel-policy, `kw.oci.getManifest()` function to return it as map.

To honour this new contract with the json tags, mark fields as exported.
This also simplifies creating mocks with this type struct without type casting.


Note that API is still backwards compatible as we were using the fields via the getters, which are untouched. Plus, cel-policy seems to be the first consumer of this. 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI, and the followup cel-policy PR.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
