### PR TITLE
fix: make verify_v2 types public

### DIFF
--- a/pkg/capabilities/oci/verify_v2/types.go
+++ b/pkg/capabilities/oci/verify_v2/types.go
@@ -13,9 +13,9 @@ type KeylessPrefixInfo struct {
 	UrlPrefix string `json:"url_prefix"`
 }
 
-// sigstorePubKeysVerify represents the WaPC JSON contract, used for marshalling
+// SigstorePubKeysVerify represents the WaPC JSON contract, used for marshalling
 // and unmarshalling payloads to wapc host calls
-type sigstorePubKeysVerify struct {
+type SigstorePubKeysVerify struct {
 	Type SigstorePubKeyVerifyType `json:"type"`
 	// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	Image string `json:"image"`
@@ -26,9 +26,9 @@ type sigstorePubKeysVerify struct {
 	Annotations map[string]string `json:"annotations"`
 }
 
-// sigstoreKeylessVerifyExact represents the WaPC JSON contract, used for marshalling
+// SigstoreKeylessVerifyExact represents the WaPC JSON contract, used for marshalling
 // and unmarshalling payloads to wapc host calls
-type sigstoreKeylessVerifyExact struct {
+type SigstoreKeylessVerifyExact struct {
 	Type SigstoreKeylessVerifyType `json:"type"`
 	// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	Image string `json:"image"`
@@ -41,7 +41,7 @@ type sigstoreKeylessVerifyExact struct {
 
 // sigstoreKeylessVerify represents the WaPC JSON contract, used for marshalling
 // and unmarshalling payloads to wapc host calls
-type sigstoreKeylessPrefixVerify struct {
+type SigstoreKeylessPrefixVerify struct {
 	Type SigstoreKeylessPrefixVerifyType `json:"type"`
 	// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	Image string `json:"image"`
@@ -52,7 +52,7 @@ type sigstoreKeylessPrefixVerify struct {
 	Annotations map[string]string `json:"annotations"`
 }
 
-type sigstoreGithubActionsVerify struct {
+type SigstoreGithubActionsVerify struct {
 	Type SigstoreGithubActionsVerifyType `json:"type"`
 	// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	Image string `json:"image"`
@@ -65,7 +65,7 @@ type sigstoreGithubActionsVerify struct {
 	Annotations map[string]string `json:"annotations"`
 }
 
-type sigstoreCertificateVerify struct {
+type SigstoreCertificateVerify struct {
 	Type SigstoreCertificateVerifyType `json:"type"`
 	// String pointing to the object (e.g.: `registry.testing.lan/busybox:1.0.0`)
 	Image string `json:"image"`

--- a/pkg/capabilities/oci/verify_v2/verify_v2.go
+++ b/pkg/capabilities/oci/verify_v2/verify_v2.go
@@ -43,7 +43,7 @@ func (e SigstoreCertificateVerifyType) MarshalJSON() ([]byte, error) {
 // * pubKeys: list of PEM encoded keys that must have been used to sign the OCI object
 // * annotations: annotations that must have been provided by all signers when they signed the OCI artifact
 func VerifyPubKeysImage(h *cap.Host, image string, pubKeys []string, annotations map[string]string) (oci.VerificationResponse, error) {
-	requestObj := sigstorePubKeysVerify{
+	requestObj := SigstorePubKeysVerify{
 		Image:       image,
 		PubKeys:     pubKeys,
 		Annotations: annotations,
@@ -58,7 +58,7 @@ func VerifyPubKeysImage(h *cap.Host, image string, pubKeys []string, annotations
 // * keyless: list of KeylessInfo pairs, containing Issuer and Subject info from OIDC providers
 // * annotations: annotations that must have been provided by all signers when they signed the OCI artifact
 func VerifyKeylessExactMatch(h *cap.Host, image string, keyless []oci.KeylessInfo, annotations map[string]string) (oci.VerificationResponse, error) {
-	requestObj := sigstoreKeylessVerifyExact{
+	requestObj := SigstoreKeylessVerifyExact{
 		Image:       image,
 		Keyless:     keyless,
 		Annotations: annotations,
@@ -76,7 +76,7 @@ func VerifyKeylessExactMatch(h *cap.Host, image string, keyless []oci.KeylessInf
 // * `keyless`  -  list of issuers and subjects
 // * `annotations` - annotations that must have been provided by all signers when they signed the OCI artifact
 func VerifyKeylessPrefixMatch(h *cap.Host, image string, keylessPrefix []KeylessPrefixInfo, annotations map[string]string) (oci.VerificationResponse, error) {
-	requestObj := sigstoreKeylessPrefixVerify{
+	requestObj := SigstoreKeylessPrefixVerify{
 		Image:         image,
 		KeylessPrefix: keylessPrefix,
 		Annotations:   annotations,
@@ -93,7 +93,7 @@ func VerifyKeylessPrefixMatch(h *cap.Host, image string, keylessPrefix []Keyless
 // * `repo` - Optional. repo of the GH Action workflow that signed the artifact. E.g: example-repo. Optional.
 // * `annotations` - annotations that must have been provided by all signers when they signed the OCI artifact
 func VerifyKeylessGithubActions(h *cap.Host, image string, owner string, repo string, annotations map[string]string) (oci.VerificationResponse, error) {
-	requestObj := sigstoreGithubActionsVerify{
+	requestObj := SigstoreGithubActionsVerify{
 		Image:       image,
 		Owner:       owner,
 		Repo:        repo,
@@ -117,7 +117,7 @@ func VerifyKeylessGithubActions(h *cap.Host, image string, owner string, repo st
 //     verification process.
 //   - `annotations` - annotations that must have been provided by all signers when they signed the OCI artifact
 func VerifyCertificate(h *cap.Host, image string, certificate []rune, certificateChain [][]rune, requireRekorBundle bool, annotations map[string]string) (oci.VerificationResponse, error) {
-	requestObj := sigstoreCertificateVerify{
+	requestObj := SigstoreCertificateVerify{
 		Image:              image,
 		Certificate:        certificate,
 		CertificateChain:   certificateChain,

--- a/pkg/capabilities/oci/verify_v2/verify_v2_test.go
+++ b/pkg/capabilities/oci/verify_v2/verify_v2_test.go
@@ -1,9 +1,8 @@
 package verify_v2
 
 import (
-	"testing"
-
 	"encoding/json"
+	"testing"
 
 	"github.com/golang/mock/gomock"
 	mock_capabilities "github.com/kubewarden/policy-sdk-go/mock/capabilities"
@@ -23,7 +22,7 @@ func TestV2Verify(t *testing.T) {
 
 	for description, testCase := range map[string]v2VerifyTestCase{
 		"PubKeysImage": {
-			request: sigstorePubKeysVerify{
+			request: SigstorePubKeysVerify{
 				Image:       "myimage:latest",
 				PubKeys:     []string{"pubkey1", "pubkey2"},
 				Annotations: nil,
@@ -32,7 +31,7 @@ func TestV2Verify(t *testing.T) {
 			checkIsTrustedFunc: CheckPubKeysImageTrusted,
 		},
 		"KeylessExactMatch": {
-			request: sigstoreKeylessVerifyExact{
+			request: SigstoreKeylessVerifyExact{
 				Image: "myimage:latest",
 				Keyless: []oci.KeylessInfo{
 					{Issuer: "https://github.com/login/oauth", Subject: "mail@example.com"},
@@ -43,7 +42,7 @@ func TestV2Verify(t *testing.T) {
 			checkIsTrustedFunc: CheckKeylessExactMatchTrusted,
 		},
 		"KeylessPrefixMatch": {
-			request: sigstoreKeylessPrefixVerify{
+			request: SigstoreKeylessPrefixVerify{
 				Image: "myimage:latest",
 				KeylessPrefix: []KeylessPrefixInfo{
 					{Issuer: "https://github.com/login/oauth", UrlPrefix: "https://example.com"},
@@ -54,7 +53,7 @@ func TestV2Verify(t *testing.T) {
 			checkIsTrustedFunc: CheckKeylessPrefixMatchTrusted,
 		},
 		"KeylessGithubActions": {
-			request: sigstoreGithubActionsVerify{
+			request: SigstoreGithubActionsVerify{
 				Image:       "myimage:latest",
 				Owner:       "myorg",
 				Repo:        "myrepo",
@@ -64,7 +63,7 @@ func TestV2Verify(t *testing.T) {
 			checkIsTrustedFunc: CheckKeylessGithubActionsTrusted,
 		},
 		"Certificate": {
-			request: sigstoreCertificateVerify{
+			request: SigstoreCertificateVerify{
 				Image:              "myimage:latest",
 				Certificate:        []rune("certificate0"),
 				CertificateChain:   [][]rune{[]rune("certificate1"), []rune("certificate2")},
@@ -107,7 +106,7 @@ func TestV2Verify(t *testing.T) {
 }
 
 func CheckPubKeysImageTrusted(host *cap.Host, request interface{}) (bool, error) {
-	requestPubKeys := request.(sigstorePubKeysVerify)
+	requestPubKeys := request.(SigstorePubKeysVerify)
 	res, err := VerifyPubKeysImage(host, requestPubKeys.Image, requestPubKeys.PubKeys, requestPubKeys.Annotations)
 	if err != nil {
 		return false, err
@@ -116,7 +115,7 @@ func CheckPubKeysImageTrusted(host *cap.Host, request interface{}) (bool, error)
 }
 
 func CheckKeylessExactMatchTrusted(host *cap.Host, request interface{}) (bool, error) {
-	requestKeylessExactMatch := request.(sigstoreKeylessVerifyExact)
+	requestKeylessExactMatch := request.(SigstoreKeylessVerifyExact)
 	res, err := VerifyKeylessExactMatch(host, requestKeylessExactMatch.Image, requestKeylessExactMatch.Keyless, requestKeylessExactMatch.Annotations)
 	if err != nil {
 		return false, err
@@ -125,7 +124,7 @@ func CheckKeylessExactMatchTrusted(host *cap.Host, request interface{}) (bool, e
 }
 
 func CheckKeylessPrefixMatchTrusted(host *cap.Host, request interface{}) (bool, error) {
-	requestKeylessPrefixMatch := request.(sigstoreKeylessPrefixVerify)
+	requestKeylessPrefixMatch := request.(SigstoreKeylessPrefixVerify)
 	res, err := VerifyKeylessPrefixMatch(host, requestKeylessPrefixMatch.Image, requestKeylessPrefixMatch.KeylessPrefix, requestKeylessPrefixMatch.Annotations)
 	if err != nil {
 		return false, err
@@ -134,7 +133,7 @@ func CheckKeylessPrefixMatchTrusted(host *cap.Host, request interface{}) (bool, 
 }
 
 func CheckKeylessGithubActionsTrusted(host *cap.Host, request interface{}) (bool, error) {
-	requestKeylessGithubActions := request.(sigstoreGithubActionsVerify)
+	requestKeylessGithubActions := request.(SigstoreGithubActionsVerify)
 	res, err := VerifyKeylessGithubActions(host, requestKeylessGithubActions.Image, requestKeylessGithubActions.Owner, requestKeylessGithubActions.Repo, requestKeylessGithubActions.Annotations)
 	if err != nil {
 		return false, err
@@ -143,7 +142,7 @@ func CheckKeylessGithubActionsTrusted(host *cap.Host, request interface{}) (bool
 }
 
 func CheckCertificateTrusted(host *cap.Host, request interface{}) (bool, error) {
-	requestCertificate := request.(sigstoreCertificateVerify)
+	requestCertificate := request.(SigstoreCertificateVerify)
 
 	res, err := VerifyCertificate(host, requestCertificate.Image, requestCertificate.Certificate, requestCertificate.CertificateChain, requestCertificate.RequireRekorBundle, requestCertificate.Annotations)
 	if err != nil {


### PR DESCRIPTION
## Description

Types used to build host call requests need to be public so we can use them to build mocks in other projects (i.e. cel policy host capabilities mocks)