### PR TITLE
fix: sigstore verification of GH action without repo

### DIFF
--- a/pkg/capabilities/oci/verify_v2/types.go
+++ b/pkg/capabilities/oci/verify_v2/types.go
@@ -59,7 +59,7 @@ type SigstoreGithubActionsVerify struct {
 	// owner of the repository. E.g: octocat
 	Owner string `json:"owner"`
 	// Optional - Repo of the GH Action workflow that signed the artifact. E.g: example-repo
-	Repo string `json:"repo"`
+	Repo string `json:"repo,omitempty"`
 	// Annotations that must have been provided by all signers when they signed
 	// the OCI artifact. Optional
 	Annotations map[string]string `json:"annotations"`

--- a/pkg/capabilities/oci/verify_v2/verify_v2_test.go
+++ b/pkg/capabilities/oci/verify_v2/verify_v2_test.go
@@ -50,7 +50,7 @@ func TestV2Verify(t *testing.T) {
 			expectedPayload:    `{"type":"SigstoreKeylessPrefixVerify","image":"myimage:latest","keyless_prefix":[{"issuer":"https://github.com/login/oauth","url_prefix":"https://example.com"}],"annotations":null}`,
 			checkIsTrustedFunc: CheckKeylessPrefixMatchTrusted,
 		},
-		"KeylessGithubActions": {
+		"KeylessGithubActionsWithOrgAndRepo": {
 			request: SigstoreGithubActionsVerify{
 				Image:       "myimage:latest",
 				Owner:       "myorg",
@@ -58,6 +58,15 @@ func TestV2Verify(t *testing.T) {
 				Annotations: nil,
 			},
 			expectedPayload:    `{"type":"SigstoreGithubActionsVerify","image":"myimage:latest","owner":"myorg","repo":"myrepo","annotations":null}`,
+			checkIsTrustedFunc: CheckKeylessGithubActionsTrusted,
+		},
+		"KeylessGithubActionsWithOrgNoRepo": {
+			request: SigstoreGithubActionsVerify{
+				Image:       "myimage:latest",
+				Owner:       "myorg",
+				Annotations: nil,
+			},
+			expectedPayload:    `{"type":"SigstoreGithubActionsVerify","image":"myimage:latest","owner":"myorg","annotations":null}`,
 			checkIsTrustedFunc: CheckKeylessGithubActionsTrusted,
 		},
 		"Certificate": {


### PR DESCRIPTION
When doing a GH action verification the repository is optional, that means we don't have to send it to the waPC host when it's not set.

Once merged we should tag a patch release of the SDK.
