### PR TITLE
fix: support changes done by TinyGo 0.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ lint:
 
 deps:
 	go get github.com/golangci/golangci-lint/cmd/golangci-lint
+	go install github.com/vektra/mockery/v2@v2.43.2
 
 generate-mocks:
 	mockery

--- a/log_writer_native.go
+++ b/log_writer_native.go
@@ -1,5 +1,5 @@
-//go:build !wasi
-// +build !wasi
+//go:build !tinygo
+// +build !tinygo
 
 // note well: we have to use the tinygo wasi target, because the wasm one is
 // meant to be used inside of the browser

--- a/log_writer_tinygo.go
+++ b/log_writer_tinygo.go
@@ -1,5 +1,5 @@
-//go:build wasi
-// +build wasi
+//go:build tinygo
+// +build tinygo
 
 // note well: we have to use the tinygo wasi target, because the wasm one is
 // meant to be used inside of the browser

--- a/pkg/capabilities/hostcaller_gc_wasip1.go
+++ b/pkg/capabilities/hostcaller_gc_wasip1.go
@@ -1,5 +1,5 @@
-//go:build wasip1 && !wasi
-// +build wasip1,!wasi
+//go:build wasip1 && !tinygo
+// +build wasip1,!tinygo
 
 // note well: we have to use the tinygo wasi target, because the wasm one is
 // meant to be used inside of the browser

--- a/pkg/capabilities/hostcaller_tinygo.go
+++ b/pkg/capabilities/hostcaller_tinygo.go
@@ -1,5 +1,5 @@
-//go:build wasi && !wasip1
-// +build wasi,!wasip1
+//go:build tinygo
+// +build tinygo
 
 // note well: we have to use the tinygo wasi target, because the wasm one is
 // meant to be used inside of the browser

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,5 +1,5 @@
-//go:build !wasip1
-// +build !wasip1
+//go:build tinygo
+// +build tinygo
 
 package protocol
 


### PR DESCRIPTION
Starting from TinyGo 0.32.0 release, the `wasi` target has been renamed to `wasip1` to match the one used by the Go official compiler (aka `gc`).

This change broke some of our build tags. For example, the `protocol` file was no longer built by our wapc policies, causing errors when the policy was being annotated.

This commit changes the build tags to use the `tinygo` build tag to identify builds done by TinyGo. The assumption is: we use TinyGo only to build WebAssembly modules (not to build x86_64 ones), hence we can safely assume that, when this build tag is found, we're building a policy that is meant to be used with WaPC.

Policies being built with older versions of TinyGo will keep working fine, since this build tag has seems to have always been part of TinyGo

Note well: I've renamed some files to make explicit they are used by `tinygo` builds.

Once this PR is merged we will need to tag a new version of the library. I would propose a minor release, not a patch one.
