### PR TITLE
chore: updates golang linter.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
-          version: "v2.0.2"
+          version: "v2.1.0"


### PR DESCRIPTION
## Description

Updates the golang linter used in the CI workflow to v2.1.0.

Required to make the CI [here](https://github.com/kubewarden/policy-sdk-go/pull/113) happy