### PR TITLE
feat: Add support for can_i host capability

### DIFF
--- a/pkg/capabilities/kubernetes/kubernetes.go
+++ b/pkg/capabilities/kubernetes/kubernetes.go
@@ -57,3 +57,24 @@ func GetResource(h *capabilities.Host, req GetResourceRequest) ([]byte, error) {
 
 	return responsePayload, nil
 }
+
+// CanI checks if the user has permissions to perform an action on resources.
+func CanI(h *capabilities.Host, req SubjectAccessReviewRequest) (SubjectAccessReviewStatus, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return SubjectAccessReviewStatus{}, fmt.Errorf("cannot serialize request object: %w", err)
+	}
+
+	// perform callback
+	responsePayload, err := h.Client.HostCall("kubewarden", "kubernetes", "can_i", payload)
+	if err != nil {
+		return SubjectAccessReviewStatus{}, err
+	}
+
+	responseObj := SubjectAccessReviewStatus{}
+	if err = json.Unmarshal(responsePayload, &responseObj); err != nil {
+		return SubjectAccessReviewStatus{}, fmt.Errorf("cannot unmarshall response object: %w", err)
+	}
+
+	return responseObj, nil
+}

--- a/pkg/capabilities/kubernetes/types.go
+++ b/pkg/capabilities/kubernetes/types.go
@@ -46,3 +46,54 @@ type GetResourceRequest struct {
 	// might cause issues to the cluster
 	DisableCache bool `json:"disable_cache"`
 }
+
+// SubjectAccessReviewRequest represents an  authorization.k9s.io/v1
+// SubjectAccessReview, used by the `can_i` function.
+type SubjectAccessReviewRequest struct {
+	APIVersion string `json:"apiVersion"`
+	// Singular PascalCase name of the resource
+	Kind string `json:"kind"`
+	// Spec of the SubjectAccessReview
+	Spec SubjectAccessReviewSpec `json:"spec"`
+	// Disable caching of results obtained from Kubernetes API Server
+	// By default query results are cached for 5 seconds, that might cause
+	// stale data to be returned.
+	// However, making too many requests against the Kubernetes API Server
+	// might cause issues to the cluster
+	DisableCache bool `json:"disable_cache"`
+}
+
+// SubjectAccessReviewSpec represents the spec field for a SubjectAccessReview.
+type SubjectAccessReviewSpec struct {
+	ResourceAttributes ResourceAttributes `json:"resourceAttributes"`
+	User               string             `json:"user"`
+	Groups             []string           `json:"groups"`
+}
+
+// ResourceAttributes describes information for a resource request.
+type ResourceAttributes struct {
+	Namespace string `json:"namespace"`
+	Verb      string `json:"verb"`
+	Group     string `json:"group"`
+	Resource  string `json:"resource"`
+}
+
+// SubjectAccessReviewStatus holds the result of the `can_i` function.
+// Analogous to authorization.k9s.io/v1 SubjectAccessReviewStatus.
+type SubjectAccessReviewStatus struct {
+	// True if the action would be allowed, false otherwise.
+	Allowed bool `json:"allowed"`
+	// Optional. True if the action would be denied, otherwise false. If both
+	// allowed is false and denied is false, then the authorizer has no opinion
+	// on whether to authorize the action.
+	// Denied may not be true if Allowed is true.
+	Denied bool `json:"denied,omitempty"`
+	// Optional. Indicates why a request was allowed or denied.
+	Reason string `json:"reason,omitempty"`
+	// Optional. Is an indication that some error occurred during the
+	// authorization check. It is entirely possible to get an error and be able
+	// to continue determine authorization status in spite of it. For instance,
+	// RBAC can be missing a role, but enough roles are still present and bound
+	// to reason about the request.
+	EvaluationError string `json:"evaluationError,omitempty"`
+}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Part of https://github.com/kubewarden/policy-sdk-go/issues/116

Implement new `CanI()` function capability under the kubernetes capabilities.

This capability checks if the user has permissions to perform an action on resources.

It accepts a `SubjectAccessReviewRequest` struct as input, with its (`spec` as `interface{}`), and returns a `SubjectAccessReviewStatus` struct.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Added a simple unit test.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
The structs could come from github.com/kubewarden/k8s-objects instead of declared here.