### PR TITLE
Check full GVK for PodSpec helpers

### DIFF
--- a/kubewarden.go
+++ b/kubewarden.go
@@ -35,7 +35,9 @@ const supportedPodSpecObjects = "apps/v1 Deployment, " +
 
 const supportedPodSpecObjectsMessage = "Object should be one of these group/version/kinds: " + supportedPodSpecObjects
 
-const supportedPodSpecObjectsError = "object should be one of these group/version/kinds: " + supportedPodSpecObjects
+const supportedPodSpecObjectsErrorMessage = "object should be one of these group/version/kinds: " + supportedPodSpecObjects
+
+var errUnsupportedPodSpecObject = errors.New(supportedPodSpecObjectsErrorMessage)
 
 // AcceptRequest can be used inside of the `validate` function to accept the
 // incoming request.
@@ -82,74 +84,180 @@ func isV1GroupKind(gvk protocol.GroupVersionKind, group, kind string) bool {
 	return gvk.Group == group && gvk.Version == "v1" && gvk.Kind == kind
 }
 
+type podSpecTarget struct {
+	object  interface{}
+	podSpec **corev1.PodSpec
+}
+
+func (target podSpecTarget) podSpecValue() corev1.PodSpec {
+	return **target.podSpec
+}
+
+func (target podSpecTarget) replacePodSpec(podSpec corev1.PodSpec) {
+	*target.podSpec = &podSpec
+}
+
+func missingPodSpecError(kind string) error {
+	return errors.New(kind + " object does not contain a PodSpec")
+}
+
+func podSpecFromTemplate(kind string, template *corev1.PodTemplateSpec) (*corev1.PodSpec, error) {
+	if template == nil || template.Spec == nil {
+		return nil, missingPodSpecError(kind)
+	}
+
+	return template.Spec, nil
+}
+
+func podSpecTargetFromTemplate(kind string, object interface{}, template *corev1.PodTemplateSpec) (podSpecTarget, error) {
+	if _, err := podSpecFromTemplate(kind, template); err != nil {
+		return podSpecTarget{}, err
+	}
+
+	return podSpecTarget{
+		object:  object,
+		podSpec: &template.Spec,
+	}, nil
+}
+
+func deploymentPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	deployment := appsv1.Deployment{}
+	if err := json.Unmarshal(rawObject, &deployment); err != nil {
+		return podSpecTarget{}, err
+	}
+	if deployment.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("Deployment")
+	}
+
+	return podSpecTargetFromTemplate("Deployment", &deployment, deployment.Spec.Template)
+}
+
+func replicaSetPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	replicaset := appsv1.ReplicaSet{}
+	if err := json.Unmarshal(rawObject, &replicaset); err != nil {
+		return podSpecTarget{}, err
+	}
+	if replicaset.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("ReplicaSet")
+	}
+
+	return podSpecTargetFromTemplate("ReplicaSet", &replicaset, replicaset.Spec.Template)
+}
+
+func statefulSetPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	statefulset := appsv1.StatefulSet{}
+	if err := json.Unmarshal(rawObject, &statefulset); err != nil {
+		return podSpecTarget{}, err
+	}
+	if statefulset.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("StatefulSet")
+	}
+
+	return podSpecTargetFromTemplate("StatefulSet", &statefulset, statefulset.Spec.Template)
+}
+
+func daemonSetPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	daemonset := appsv1.DaemonSet{}
+	if err := json.Unmarshal(rawObject, &daemonset); err != nil {
+		return podSpecTarget{}, err
+	}
+	if daemonset.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("DaemonSet")
+	}
+
+	return podSpecTargetFromTemplate("DaemonSet", &daemonset, daemonset.Spec.Template)
+}
+
+func replicationControllerPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	replicationController := corev1.ReplicationController{}
+	if err := json.Unmarshal(rawObject, &replicationController); err != nil {
+		return podSpecTarget{}, err
+	}
+	if replicationController.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("ReplicationController")
+	}
+
+	return podSpecTargetFromTemplate("ReplicationController", &replicationController, replicationController.Spec.Template)
+}
+
+func cronJobPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	cronjob := batchv1.CronJob{}
+	if err := json.Unmarshal(rawObject, &cronjob); err != nil {
+		return podSpecTarget{}, err
+	}
+	if cronjob.Spec == nil || cronjob.Spec.JobTemplate == nil || cronjob.Spec.JobTemplate.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("CronJob")
+	}
+
+	return podSpecTargetFromTemplate("CronJob", &cronjob, cronjob.Spec.JobTemplate.Spec.Template)
+}
+
+func jobPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	job := batchv1.Job{}
+	if err := json.Unmarshal(rawObject, &job); err != nil {
+		return podSpecTarget{}, err
+	}
+	if job.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("Job")
+	}
+
+	return podSpecTargetFromTemplate("Job", &job, job.Spec.Template)
+}
+
+func podPodSpecTarget(rawObject json.RawMessage) (podSpecTarget, error) {
+	pod := corev1.Pod{}
+	if err := json.Unmarshal(rawObject, &pod); err != nil {
+		return podSpecTarget{}, err
+	}
+	if pod.Spec == nil {
+		return podSpecTarget{}, missingPodSpecError("Pod")
+	}
+
+	return podSpecTarget{
+		object:  &pod,
+		podSpec: &pod.Spec,
+	}, nil
+}
+
+func podSpecTargetFromRequest(validationRequest protocol.ValidationRequest) (podSpecTarget, error) {
+	gvk := validationRequest.Request.Kind
+	switch {
+	case isV1GroupKind(gvk, appsv1.GroupName, "Deployment"):
+		return deploymentPodSpecTarget(validationRequest.Request.Object)
+	case isV1GroupKind(gvk, appsv1.GroupName, "ReplicaSet"):
+		return replicaSetPodSpecTarget(validationRequest.Request.Object)
+	case isV1GroupKind(gvk, appsv1.GroupName, "StatefulSet"):
+		return statefulSetPodSpecTarget(validationRequest.Request.Object)
+	case isV1GroupKind(gvk, appsv1.GroupName, "DaemonSet"):
+		return daemonSetPodSpecTarget(validationRequest.Request.Object)
+	case isV1GroupKind(gvk, corev1.GroupName, "ReplicationController"):
+		return replicationControllerPodSpecTarget(validationRequest.Request.Object)
+	case isV1GroupKind(gvk, batchv1.GroupName, "CronJob"):
+		return cronJobPodSpecTarget(validationRequest.Request.Object)
+	case isV1GroupKind(gvk, batchv1.GroupName, "Job"):
+		return jobPodSpecTarget(validationRequest.Request.Object)
+	case isV1GroupKind(gvk, corev1.GroupName, "Pod"):
+		return podPodSpecTarget(validationRequest.Request.Object)
+	default:
+		return podSpecTarget{}, errUnsupportedPodSpecObject
+	}
+}
+
 // MutatePodSpecFromRequest updates the pod spec from the resource defined in the original object and
 // create an acceptance response.
 // * `validation_request` - the original admission request
 // * `pod_spec` - new PodSpec to be set in the response.
-//
-//nolint:funlen // Splitting this function would not make it more readable.
-func MutatePodSpecFromRequest(validationRequest protocol.ValidationRequest, podSepc corev1.PodSpec) ([]byte, error) {
-	gvk := validationRequest.Request.Kind
-	switch {
-	case isV1GroupKind(gvk, appsv1.GroupName, "Deployment"):
-		deployment := appsv1.Deployment{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &deployment); err != nil {
-			return nil, err
-		}
-		deployment.Spec.Template.Spec = &podSepc
-		return MutateRequest(deployment)
-	case isV1GroupKind(gvk, appsv1.GroupName, "ReplicaSet"):
-		replicaset := appsv1.ReplicaSet{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &replicaset); err != nil {
-			return nil, err
-		}
-		replicaset.Spec.Template.Spec = &podSepc
-		return MutateRequest(replicaset)
-	case isV1GroupKind(gvk, appsv1.GroupName, "StatefulSet"):
-		statefulset := appsv1.StatefulSet{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &statefulset); err != nil {
-			return nil, err
-		}
-		statefulset.Spec.Template.Spec = &podSepc
-		return MutateRequest(statefulset)
-	case isV1GroupKind(gvk, appsv1.GroupName, "DaemonSet"):
-		daemonset := appsv1.DaemonSet{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &daemonset); err != nil {
-			return nil, err
-		}
-		daemonset.Spec.Template.Spec = &podSepc
-		return MutateRequest(daemonset)
-	case isV1GroupKind(gvk, corev1.GroupName, "ReplicationController"):
-		replicationController := corev1.ReplicationController{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &replicationController); err != nil {
-			return nil, err
-		}
-		replicationController.Spec.Template.Spec = &podSepc
-		return MutateRequest(replicationController)
-	case isV1GroupKind(gvk, batchv1.GroupName, "CronJob"):
-		cronjob := batchv1.CronJob{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &cronjob); err != nil {
-			return nil, err
-		}
-		cronjob.Spec.JobTemplate.Spec.Template.Spec = &podSepc
-		return MutateRequest(cronjob)
-	case isV1GroupKind(gvk, batchv1.GroupName, "Job"):
-		job := batchv1.Job{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &job); err != nil {
-			return nil, err
-		}
-		job.Spec.Template.Spec = &podSepc
-		return MutateRequest(job)
-	case isV1GroupKind(gvk, corev1.GroupName, "Pod"):
-		pod := corev1.Pod{}
-		if err := json.Unmarshal(validationRequest.Request.Object, &pod); err != nil {
-			return nil, err
-		}
-		pod.Spec = &podSepc
-		return MutateRequest(pod)
-	default:
+func MutatePodSpecFromRequest(validationRequest protocol.ValidationRequest, podSpec corev1.PodSpec) ([]byte, error) {
+	target, err := podSpecTargetFromRequest(validationRequest)
+	if errors.Is(err, errUnsupportedPodSpecObject) {
 		return RejectRequest(supportedPodSpecObjectsMessage, NoCode)
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	target.replacePodSpec(podSpec)
+	return MutateRequest(target.object)
 }
 
 // AcceptSettings can be used inside of the `validate_settings` function to
@@ -182,61 +290,13 @@ func RejectSettings(message Message) ([]byte, error) {
 // that violate a policy instead of the Pods created by them.
 // Objects supported are: Deployment, ReplicaSet, StatefulSet,
 // DaemonSet, ReplicationController, Job, CronJob, Pod It returns an error if
-// the object is not one of those. If it is a supported object it returns the
-// PodSpec if present, otherwise returns an empty PodSpec.
+// the object is not one of those or does not contain a PodSpec.
 // * `object`: the request to validate.
 func ExtractPodSpecFromObject(object protocol.ValidationRequest) (corev1.PodSpec, error) {
-	gvk := object.Request.Kind
-	switch {
-	case isV1GroupKind(gvk, appsv1.GroupName, "Deployment"):
-		deployment := appsv1.Deployment{}
-		if err := json.Unmarshal(object.Request.Object, &deployment); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *deployment.Spec.Template.Spec, nil
-	case isV1GroupKind(gvk, appsv1.GroupName, "ReplicaSet"):
-		replicaset := appsv1.ReplicaSet{}
-		if err := json.Unmarshal(object.Request.Object, &replicaset); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *replicaset.Spec.Template.Spec, nil
-	case isV1GroupKind(gvk, appsv1.GroupName, "StatefulSet"):
-		statefulset := appsv1.StatefulSet{}
-		if err := json.Unmarshal(object.Request.Object, &statefulset); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *statefulset.Spec.Template.Spec, nil
-	case isV1GroupKind(gvk, appsv1.GroupName, "DaemonSet"):
-		daemonset := appsv1.DaemonSet{}
-		if err := json.Unmarshal(object.Request.Object, &daemonset); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *daemonset.Spec.Template.Spec, nil
-	case isV1GroupKind(gvk, corev1.GroupName, "ReplicationController"):
-		replicationController := corev1.ReplicationController{}
-		if err := json.Unmarshal(object.Request.Object, &replicationController); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *replicationController.Spec.Template.Spec, nil
-	case isV1GroupKind(gvk, batchv1.GroupName, "CronJob"):
-		cronjob := batchv1.CronJob{}
-		if err := json.Unmarshal(object.Request.Object, &cronjob); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *cronjob.Spec.JobTemplate.Spec.Template.Spec, nil
-	case isV1GroupKind(gvk, batchv1.GroupName, "Job"):
-		job := batchv1.Job{}
-		if err := json.Unmarshal(object.Request.Object, &job); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *job.Spec.Template.Spec, nil
-	case isV1GroupKind(gvk, corev1.GroupName, "Pod"):
-		pod := corev1.Pod{}
-		if err := json.Unmarshal(object.Request.Object, &pod); err != nil {
-			return corev1.PodSpec{}, err
-		}
-		return *pod.Spec, nil
-	default:
-		return corev1.PodSpec{}, errors.New(supportedPodSpecObjectsError)
+	target, err := podSpecTargetFromRequest(object)
+	if err != nil {
+		return corev1.PodSpec{}, err
 	}
+
+	return target.podSpecValue(), nil
 }

--- a/kubewarden.go
+++ b/kubewarden.go
@@ -5,7 +5,7 @@ package sdk
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 
 	appsv1 "github.com/kubewarden/k8s-objects/api/apps/v1"
 	batchv1 "github.com/kubewarden/k8s-objects/api/batch/v1"
@@ -27,16 +27,15 @@ const (
 	// NoCode can be used when building a response that doesn't have any
 	// error code to be shown to the user.
 	NoCode Code = 0
-
-	kindDeployment            = "Deployment"
-	kindReplicaSet            = "ReplicaSet"
-	kindStatefulSet           = "StatefulSet"
-	kindDaemonSet             = "DaemonSet"
-	kindReplicationController = "ReplicationController"
-	kindCronJob               = "CronJob"
-	kindJob                   = "Job"
-	kindPod                   = "Pod"
 )
+
+const supportedPodSpecObjects = "apps/v1 Deployment, " +
+	"apps/v1 ReplicaSet, apps/v1 StatefulSet, apps/v1 DaemonSet, v1 ReplicationController, " +
+	"batch/v1 Job, batch/v1 CronJob, v1 Pod"
+
+const supportedPodSpecObjectsMessage = "Object should be one of these group/version/kinds: " + supportedPodSpecObjects
+
+const supportedPodSpecObjectsError = "object should be one of these group/version/kinds: " + supportedPodSpecObjects
 
 // AcceptRequest can be used inside of the `validate` function to accept the
 // incoming request.
@@ -79,6 +78,10 @@ func MutateRequest(newObject any) ([]byte, error) {
 	return json.Marshal(response)
 }
 
+func isV1GroupKind(gvk protocol.GroupVersionKind, group, kind string) bool {
+	return gvk.Group == group && gvk.Version == "v1" && gvk.Kind == kind
+}
+
 // MutatePodSpecFromRequest updates the pod spec from the resource defined in the original object and
 // create an acceptance response.
 // * `validation_request` - the original admission request
@@ -86,57 +89,58 @@ func MutateRequest(newObject any) ([]byte, error) {
 //
 //nolint:funlen // Splitting this function would not make it more readable.
 func MutatePodSpecFromRequest(validationRequest protocol.ValidationRequest, podSepc corev1.PodSpec) ([]byte, error) {
-	switch validationRequest.Request.Kind.Kind {
-	case kindDeployment:
+	gvk := validationRequest.Request.Kind
+	switch {
+	case isV1GroupKind(gvk, appsv1.GroupName, "Deployment"):
 		deployment := appsv1.Deployment{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &deployment); err != nil {
 			return nil, err
 		}
 		deployment.Spec.Template.Spec = &podSepc
 		return MutateRequest(deployment)
-	case kindReplicaSet:
+	case isV1GroupKind(gvk, appsv1.GroupName, "ReplicaSet"):
 		replicaset := appsv1.ReplicaSet{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &replicaset); err != nil {
 			return nil, err
 		}
 		replicaset.Spec.Template.Spec = &podSepc
 		return MutateRequest(replicaset)
-	case kindStatefulSet:
+	case isV1GroupKind(gvk, appsv1.GroupName, "StatefulSet"):
 		statefulset := appsv1.StatefulSet{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &statefulset); err != nil {
 			return nil, err
 		}
 		statefulset.Spec.Template.Spec = &podSepc
 		return MutateRequest(statefulset)
-	case kindDaemonSet:
+	case isV1GroupKind(gvk, appsv1.GroupName, "DaemonSet"):
 		daemonset := appsv1.DaemonSet{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &daemonset); err != nil {
 			return nil, err
 		}
 		daemonset.Spec.Template.Spec = &podSepc
 		return MutateRequest(daemonset)
-	case kindReplicationController:
+	case isV1GroupKind(gvk, corev1.GroupName, "ReplicationController"):
 		replicationController := corev1.ReplicationController{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &replicationController); err != nil {
 			return nil, err
 		}
 		replicationController.Spec.Template.Spec = &podSepc
 		return MutateRequest(replicationController)
-	case kindCronJob:
+	case isV1GroupKind(gvk, batchv1.GroupName, "CronJob"):
 		cronjob := batchv1.CronJob{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &cronjob); err != nil {
 			return nil, err
 		}
 		cronjob.Spec.JobTemplate.Spec.Template.Spec = &podSepc
 		return MutateRequest(cronjob)
-	case kindJob:
+	case isV1GroupKind(gvk, batchv1.GroupName, "Job"):
 		job := batchv1.Job{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &job); err != nil {
 			return nil, err
 		}
 		job.Spec.Template.Spec = &podSepc
 		return MutateRequest(job)
-	case kindPod:
+	case isV1GroupKind(gvk, corev1.GroupName, "Pod"):
 		pod := corev1.Pod{}
 		if err := json.Unmarshal(validationRequest.Request.Object, &pod); err != nil {
 			return nil, err
@@ -144,8 +148,7 @@ func MutatePodSpecFromRequest(validationRequest protocol.ValidationRequest, podS
 		pod.Spec = &podSepc
 		return MutateRequest(pod)
 	default:
-		return RejectRequest("Object should be one of these kinds: Deployment, "+
-			"ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod", NoCode)
+		return RejectRequest(supportedPodSpecObjectsMessage, NoCode)
 	}
 }
 
@@ -183,58 +186,57 @@ func RejectSettings(message Message) ([]byte, error) {
 // PodSpec if present, otherwise returns an empty PodSpec.
 // * `object`: the request to validate.
 func ExtractPodSpecFromObject(object protocol.ValidationRequest) (corev1.PodSpec, error) {
-	switch object.Request.Kind.Kind {
-	case kindDeployment:
+	gvk := object.Request.Kind
+	switch {
+	case isV1GroupKind(gvk, appsv1.GroupName, "Deployment"):
 		deployment := appsv1.Deployment{}
 		if err := json.Unmarshal(object.Request.Object, &deployment); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *deployment.Spec.Template.Spec, nil
-	case kindReplicaSet:
+	case isV1GroupKind(gvk, appsv1.GroupName, "ReplicaSet"):
 		replicaset := appsv1.ReplicaSet{}
 		if err := json.Unmarshal(object.Request.Object, &replicaset); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *replicaset.Spec.Template.Spec, nil
-	case kindStatefulSet:
+	case isV1GroupKind(gvk, appsv1.GroupName, "StatefulSet"):
 		statefulset := appsv1.StatefulSet{}
 		if err := json.Unmarshal(object.Request.Object, &statefulset); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *statefulset.Spec.Template.Spec, nil
-	case kindDaemonSet:
+	case isV1GroupKind(gvk, appsv1.GroupName, "DaemonSet"):
 		daemonset := appsv1.DaemonSet{}
 		if err := json.Unmarshal(object.Request.Object, &daemonset); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *daemonset.Spec.Template.Spec, nil
-	case kindReplicationController:
+	case isV1GroupKind(gvk, corev1.GroupName, "ReplicationController"):
 		replicationController := corev1.ReplicationController{}
 		if err := json.Unmarshal(object.Request.Object, &replicationController); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *replicationController.Spec.Template.Spec, nil
-	case kindCronJob:
+	case isV1GroupKind(gvk, batchv1.GroupName, "CronJob"):
 		cronjob := batchv1.CronJob{}
 		if err := json.Unmarshal(object.Request.Object, &cronjob); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *cronjob.Spec.JobTemplate.Spec.Template.Spec, nil
-	case kindJob:
+	case isV1GroupKind(gvk, batchv1.GroupName, "Job"):
 		job := batchv1.Job{}
 		if err := json.Unmarshal(object.Request.Object, &job); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *job.Spec.Template.Spec, nil
-	case kindPod:
+	case isV1GroupKind(gvk, corev1.GroupName, "Pod"):
 		pod := corev1.Pod{}
 		if err := json.Unmarshal(object.Request.Object, &pod); err != nil {
 			return corev1.PodSpec{}, err
 		}
 		return *pod.Spec, nil
 	default:
-		return corev1.PodSpec{}, fmt.Errorf("object should be one of these kinds: %s, %s, %s, %s, %s, %s, %s, %s",
-			kindDeployment, kindReplicaSet, kindStatefulSet, kindDaemonSet,
-			kindReplicationController, kindJob, kindCronJob, kindPod)
+		return corev1.PodSpec{}, errors.New(supportedPodSpecObjectsError)
 	}
 }

--- a/kubewarden_test.go
+++ b/kubewarden_test.go
@@ -18,6 +18,12 @@ type mutatePodSpecFromRequestTestCase struct {
 	mutationCheckFunc func(t interface{}) bool
 }
 
+type podSpecMissingTestCase struct {
+	kind   string
+	gvk    protocol.GroupVersionKind
+	object interface{}
+}
+
 func createValidationRequest(object interface{}, gvk protocol.GroupVersionKind) (protocol.ValidationRequest, error) {
 	value, err := json.Marshal(&object)
 
@@ -34,6 +40,132 @@ func createValidationRequest(object interface{}, gvk protocol.GroupVersionKind) 
 	}
 
 	return validationRequest, nil
+}
+
+func podSpecMissingTestCases() map[string]podSpecMissingTestCase {
+	return map[string]podSpecMissingTestCase{
+		"DeploymentWithMissingSpec": {
+			kind: "Deployment",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			object: appsv1.Deployment{},
+		},
+		"DeploymentWithMissingTemplate": {
+			kind: "Deployment",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+			object: appsv1.Deployment{
+				Spec: &appsv1.DeploymentSpec{},
+			},
+		},
+		"ReplicaSetWithMissingTemplate": {
+			kind: "ReplicaSet",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "ReplicaSet",
+			},
+			object: appsv1.ReplicaSet{
+				Spec: &appsv1.ReplicaSetSpec{},
+			},
+		},
+		"StatefulSetWithMissingTemplate": {
+			kind: "StatefulSet",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "StatefulSet",
+			},
+			object: appsv1.StatefulSet{
+				Spec: &appsv1.StatefulSetSpec{},
+			},
+		},
+		"DaemonSetWithMissingTemplate": {
+			kind: "DaemonSet",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "DaemonSet",
+			},
+			object: appsv1.DaemonSet{
+				Spec: &appsv1.DaemonSetSpec{},
+			},
+		},
+		"ReplicationControllerWithMissingTemplate": {
+			kind: "ReplicationController",
+			gvk: protocol.GroupVersionKind{
+				Group:   corev1.GroupName,
+				Version: "v1",
+				Kind:    "ReplicationController",
+			},
+			object: corev1.ReplicationController{
+				Spec: &corev1.ReplicationControllerSpec{},
+			},
+		},
+		"CronJobWithMissingSpec": {
+			kind: "CronJob",
+			gvk: protocol.GroupVersionKind{
+				Group:   batchv1.GroupName,
+				Version: "v1",
+				Kind:    "CronJob",
+			},
+			object: batchv1.CronJob{},
+		},
+		"CronJobWithMissingJobTemplateSpec": {
+			kind: "CronJob",
+			gvk: protocol.GroupVersionKind{
+				Group:   batchv1.GroupName,
+				Version: "v1",
+				Kind:    "CronJob",
+			},
+			object: batchv1.CronJob{
+				Spec: &batchv1.CronJobSpec{
+					JobTemplate: &batchv1.JobTemplateSpec{},
+				},
+			},
+		},
+		"CronJobWithMissingPodTemplate": {
+			kind: "CronJob",
+			gvk: protocol.GroupVersionKind{
+				Group:   batchv1.GroupName,
+				Version: "v1",
+				Kind:    "CronJob",
+			},
+			object: batchv1.CronJob{
+				Spec: &batchv1.CronJobSpec{
+					JobTemplate: &batchv1.JobTemplateSpec{
+						Spec: &batchv1.JobSpec{},
+					},
+				},
+			},
+		},
+		"JobWithMissingTemplate": {
+			kind: "Job",
+			gvk: protocol.GroupVersionKind{
+				Group:   batchv1.GroupName,
+				Version: "v1",
+				Kind:    "Job",
+			},
+			object: batchv1.Job{
+				Spec: &batchv1.JobSpec{},
+			},
+		},
+		"PodWithMissingSpec": {
+			kind: "Pod",
+			gvk: protocol.GroupVersionKind{
+				Group:   corev1.GroupName,
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			object: corev1.Pod{},
+		},
+	}
 }
 
 // Build a ValidationResponse object. Returns an error if the validation
@@ -270,6 +402,32 @@ func CheckPodSpecMutatedFromRequestWithJob(object interface{}) bool {
 func CheckPodSpecMutatedFromRequestWithPod(object interface{}) bool {
 	return object.(*corev1.Pod).Spec.AutomountServiceAccountToken == true
 }
+
+func TestMutatePodSpecFromRequestReturnsErrorWhenPodSpecMissing(t *testing.T) {
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	for description, testCase := range podSpecMissingTestCases() {
+		t.Run(description, func(t *testing.T) {
+			validationRequest, err := createValidationRequest(testCase.object, testCase.gvk)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+
+			_, err = MutatePodSpecFromRequest(validationRequest, newPodSpec)
+			if err == nil {
+				t.Fatalf("Expected error")
+			}
+
+			expectedError := missingPodSpecError(testCase.kind).Error()
+			if err.Error() != expectedError {
+				t.Fatalf("Expected %q, got %q", expectedError, err.Error())
+			}
+		})
+	}
+}
+
 func TestMutatePodSpecFromRequestWithInvalidResourceType(t *testing.T) {
 	pod := &corev1.Pod{}
 
@@ -400,7 +558,28 @@ func TestExtractPodSpecFromObjectRejectsMismatchedGroupVersionKind(t *testing.T)
 		t.Fatalf("Expected error")
 	}
 
-	if err.Error() != supportedPodSpecObjectsError {
+	if err.Error() != supportedPodSpecObjectsErrorMessage {
 		t.Fatalf("Different error occurred")
+	}
+}
+
+func TestExtractPodSpecFromObjectReturnsErrorWhenPodSpecMissing(t *testing.T) {
+	for description, testCase := range podSpecMissingTestCases() {
+		t.Run(description, func(t *testing.T) {
+			validationRequest, err := createValidationRequest(testCase.object, testCase.gvk)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+
+			_, err = ExtractPodSpecFromObject(validationRequest)
+			if err == nil {
+				t.Fatalf("Expected error")
+			}
+
+			expectedError := missingPodSpecError(testCase.kind).Error()
+			if err.Error() != expectedError {
+				t.Fatalf("Expected %q, got %q", expectedError, err.Error())
+			}
+		})
 	}
 }

--- a/kubewarden_test.go
+++ b/kubewarden_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 type mutatePodSpecFromRequestTestCase struct {
-	kind              string
+	gvk               protocol.GroupVersionKind
 	object            interface{}
 	mutatedObject     interface{}
 	mutationCheckFunc func(t interface{}) bool
 }
 
-func createValidationRequest(object interface{}, kind string) (protocol.ValidationRequest, error) {
+func createValidationRequest(object interface{}, gvk protocol.GroupVersionKind) (protocol.ValidationRequest, error) {
 	value, err := json.Marshal(&object)
 
 	if err != nil {
@@ -28,9 +28,7 @@ func createValidationRequest(object interface{}, kind string) (protocol.Validati
 	validationRequest := protocol.ValidationRequest{
 		Settings: json.RawMessage{},
 		Request: protocol.KubernetesAdmissionRequest{
-			Kind: protocol.GroupVersionKind{
-				Kind: kind,
-			},
+			Kind:   gvk,
 			Object: value,
 		},
 	}
@@ -71,7 +69,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 
 	for description, testCase := range map[string]mutatePodSpecFromRequestTestCase{
 		"WithDeployment": {
-			kind: "Deployment",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "Deployment",
+			},
 			object: appsv1.Deployment{
 				Spec: &appsv1.DeploymentSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -85,7 +87,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithDeployment,
 		},
 		"WithReplicaset": {
-			kind: "ReplicaSet",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "ReplicaSet",
+			},
 			object: appsv1.ReplicaSet{
 				Spec: &appsv1.ReplicaSetSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -99,7 +105,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithReplicaset,
 		},
 		"WithStatefulset": {
-			kind: "StatefulSet",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "StatefulSet",
+			},
 			object: appsv1.StatefulSet{
 				Spec: &appsv1.StatefulSetSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -113,7 +123,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithStatefulset,
 		},
 		"WithDaemonset": {
-			kind: "DaemonSet",
+			gvk: protocol.GroupVersionKind{
+				Group:   appsv1.GroupName,
+				Version: "v1",
+				Kind:    "DaemonSet",
+			},
 			object: appsv1.DaemonSet{
 				Spec: &appsv1.DaemonSetSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -127,7 +141,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithDaemonset,
 		},
 		"WithReplicationcontroller": {
-			kind: "ReplicationController",
+			gvk: protocol.GroupVersionKind{
+				Group:   corev1.GroupName,
+				Version: "v1",
+				Kind:    "ReplicationController",
+			},
 			object: corev1.ReplicationController{
 				Spec: &corev1.ReplicationControllerSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -141,7 +159,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithReplicationcontroller,
 		},
 		"WithCronjob": {
-			kind: "CronJob",
+			gvk: protocol.GroupVersionKind{
+				Group:   batchv1.GroupName,
+				Version: "v1",
+				Kind:    "CronJob",
+			},
 			object: batchv1.CronJob{
 				Spec: &batchv1.CronJobSpec{
 					JobTemplate: &batchv1.JobTemplateSpec{
@@ -159,7 +181,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithCronjob,
 		},
 		"WithJob": {
-			kind: "Job",
+			gvk: protocol.GroupVersionKind{
+				Group:   batchv1.GroupName,
+				Version: "v1",
+				Kind:    "Job",
+			},
 			object: batchv1.Job{
 				Spec: &batchv1.JobSpec{
 					Template: &corev1.PodTemplateSpec{
@@ -173,7 +199,11 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 			mutationCheckFunc: CheckPodSpecMutatedFromRequestWithJob,
 		},
 		"WithPod": {
-			kind: "Pod",
+			gvk: protocol.GroupVersionKind{
+				Group:   corev1.GroupName,
+				Version: "v1",
+				Kind:    "Pod",
+			},
 			object: corev1.Pod{
 				Spec: &corev1.PodSpec{
 					AutomountServiceAccountToken: false,
@@ -184,7 +214,7 @@ func TestMutatePodSpecFromRequest(t *testing.T) {
 		},
 	} {
 		t.Run(description, func(t *testing.T) {
-			validationRequest, err := createValidationRequest(testCase.object, testCase.kind)
+			validationRequest, err := createValidationRequest(testCase.object, testCase.gvk)
 			if err != nil {
 				t.Fatalf("Error: %v", err)
 			}
@@ -243,7 +273,7 @@ func CheckPodSpecMutatedFromRequestWithPod(object interface{}) bool {
 func TestMutatePodSpecFromRequestWithInvalidResourceType(t *testing.T) {
 	pod := &corev1.Pod{}
 
-	validationRequest, err := createValidationRequest(pod, "InvalidType")
+	validationRequest, err := createValidationRequest(pod, protocol.GroupVersionKind{Kind: "InvalidType"})
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
@@ -267,8 +297,110 @@ func TestMutatePodSpecFromRequestWithInvalidResourceType(t *testing.T) {
 	}
 
 	errorMessage := response.Message
-	expectedErrorMessage := "Object should be one of these kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, ReplicationController, Job, CronJob, Pod"
-	if *errorMessage != expectedErrorMessage {
+	if *errorMessage != supportedPodSpecObjectsMessage {
+		t.Fatalf("Different error occurred")
+	}
+}
+
+func TestMutatePodSpecFromRequestRejectsMismatchedGroupVersionKind(t *testing.T) {
+	deployment := appsv1.Deployment{
+		Spec: &appsv1.DeploymentSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: false,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := createValidationRequest(deployment, protocol.GroupVersionKind{
+		Group:   "argocd.io",
+		Version: "v1",
+		Kind:    "Deployment",
+	})
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	newPodSpec := corev1.PodSpec{
+		AutomountServiceAccountToken: true,
+	}
+
+	rawResponse, err := MutatePodSpecFromRequest(validationRequest, newPodSpec)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	response := protocol.ValidationResponse{}
+	if err = json.Unmarshal(rawResponse, &response); err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if response.Accepted {
+		t.Fatalf("Response accepted")
+	}
+
+	if response.Message == nil || *response.Message != supportedPodSpecObjectsMessage {
+		t.Fatalf("Different error occurred")
+	}
+}
+
+func TestExtractPodSpecFromObject(t *testing.T) {
+	deployment := appsv1.Deployment{
+		Spec: &appsv1.DeploymentSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: true,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := createValidationRequest(deployment, protocol.GroupVersionKind{
+		Group:   appsv1.GroupName,
+		Version: "v1",
+		Kind:    "Deployment",
+	})
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	podSpec, err := ExtractPodSpecFromObject(validationRequest)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	if !podSpec.AutomountServiceAccountToken {
+		t.Fatalf("PodSpec not extracted")
+	}
+}
+
+func TestExtractPodSpecFromObjectRejectsMismatchedGroupVersionKind(t *testing.T) {
+	deployment := appsv1.Deployment{
+		Spec: &appsv1.DeploymentSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: &corev1.PodSpec{
+					AutomountServiceAccountToken: true,
+				},
+			},
+		},
+	}
+
+	validationRequest, err := createValidationRequest(deployment, protocol.GroupVersionKind{
+		Group:   "argocd.io",
+		Version: "v1",
+		Kind:    "Deployment",
+	})
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+
+	_, err = ExtractPodSpecFromObject(validationRequest)
+	if err == nil {
+		t.Fatalf("Expected error")
+	}
+
+	if err.Error() != supportedPodSpecObjectsError {
 		t.Fatalf("Different error occurred")
 	}
 }


### PR DESCRIPTION
## Summary
- match PodSpec helper dispatch on the full request GVK instead of kind only
- reject unsupported group/version/kind combinations with a GVK-specific message
- add regression coverage for argocd.io/v1 Deployment in mutate and extract paths

Fixes #63

## Testing
- make test
- make lint
- git diff --check