### PR TITLE
feat(cache): implement Set and Get functions with request/response types

### DIFF
--- a/pkg/capabilities/cache/cache.go
+++ b/pkg/capabilities/cache/cache.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubewarden/policy-sdk-go/pkg/capabilities"
+)
+
+// Set stores value under key in the policy-controlled cache, keeping it for ttl
+// seconds.
+//
+// Keys reserved for Kubewarden's internal caches (those starting with
+// "kubewarden_internal_") are rejected by the host.
+func Set(host *capabilities.Host, key string, value []byte, ttl uint64) error {
+	request := setRequest{
+		Key:   key,
+		TTL:   ttl,
+		Value: bytesToRunes(value),
+	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("cannot serialize cache.set request to JSON: %w", err)
+	}
+
+	responsePayload, err := host.Client.HostCall("kubewarden", "cache", "set", payload)
+	if err != nil {
+		return err
+	}
+
+	response := setResponse{}
+	if err = json.Unmarshal(responsePayload, &response); err != nil {
+		return fmt.Errorf("cannot unmarshall cache.set response: %w", err)
+	}
+	if response.Code != 0 {
+		return fmt.Errorf("cache.set failed: %s", response.Message)
+	}
+
+	return nil
+}
+
+// Get retrieves the value stored under key. It returns (nil, nil) on a cache
+// miss; a miss is not an error.
+func Get(host *capabilities.Host, key string) ([]byte, error) {
+	request := getRequest{Key: key}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("cannot serialize cache.get request to JSON: %w", err)
+	}
+
+	responsePayload, err := host.Client.HostCall("kubewarden", "cache", "get", payload)
+	if err != nil {
+		return nil, err
+	}
+
+	response := getResponse{}
+	if err = json.Unmarshal(responsePayload, &response); err != nil {
+		return nil, fmt.Errorf("cannot unmarshall cache.get response: %w", err)
+	}
+	if response.Code != 0 {
+		return nil, fmt.Errorf("cache.get failed: %s", response.Message)
+	}
+	if response.Value == nil {
+		return nil, nil
+	}
+
+	return runesToBytes(response.Value), nil
+}
+
+func bytesToRunes(b []byte) []rune {
+	runes := make([]rune, len(b))
+	for i, v := range b {
+		runes[i] = rune(v)
+	}
+	return runes
+}
+
+func runesToBytes(r []rune) []byte {
+	b := make([]byte, len(r))
+	for i, v := range r {
+		b[i] = byte(v)
+	}
+	return b
+}

--- a/pkg/capabilities/cache/cache_test.go
+++ b/pkg/capabilities/cache/cache_test.go
@@ -1,0 +1,143 @@
+package cache
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/kubewarden/policy-sdk-go/pkg/capabilities"
+	"github.com/kubewarden/policy-sdk-go/pkg/capabilities/mocks"
+)
+
+func TestSet(t *testing.T) {
+	mockWapcClient := &mocks.MockWapcClient{}
+
+	key := "my-key"
+	value := []byte{1, 2, 3}
+	var ttl uint64 = 60
+
+	expectedPayload, err := json.Marshal(setRequest{
+		Key:   key,
+		TTL:   ttl,
+		Value: bytesToRunes(value),
+	})
+	if err != nil {
+		t.Fatalf("cannot serialize request: %v", err)
+	}
+
+	responsePayload, err := json.Marshal(setResponse{Code: 0, Message: "ok"})
+	if err != nil {
+		t.Fatalf("cannot serialize response: %v", err)
+	}
+
+	mockWapcClient.
+		EXPECT().
+		HostCall("kubewarden", "cache", "set", expectedPayload).
+		Return(responsePayload, nil).
+		Times(1)
+
+	host := &capabilities.Host{Client: mockWapcClient}
+
+	if err := Set(host, key, value, ttl); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetHit(t *testing.T) {
+	mockWapcClient := &mocks.MockWapcClient{}
+
+	stored := []byte{1, 2, 3}
+	responsePayload, err := json.Marshal(getResponse{
+		Code:    0,
+		Message: "hit",
+		Value:   bytesToRunes(stored),
+	})
+	if err != nil {
+		t.Fatalf("cannot serialize response: %v", err)
+	}
+
+	expectedPayload, err := json.Marshal(getRequest{Key: "my-key"})
+	if err != nil {
+		t.Fatalf("cannot serialize request: %v", err)
+	}
+
+	mockWapcClient.
+		EXPECT().
+		HostCall("kubewarden", "cache", "get", expectedPayload).
+		Return(responsePayload, nil).
+		Times(1)
+
+	host := &capabilities.Host{Client: mockWapcClient}
+
+	res, err := Get(host, "my-key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(res, stored) {
+		t.Fatalf("expected %v, got %v", stored, res)
+	}
+}
+
+func TestGetMiss(t *testing.T) {
+	mockWapcClient := &mocks.MockWapcClient{}
+
+	responsePayload, err := json.Marshal(getResponse{Code: 0, Message: "miss"})
+	if err != nil {
+		t.Fatalf("cannot serialize response: %v", err)
+	}
+
+	expectedPayload, err := json.Marshal(getRequest{Key: "absent"})
+	if err != nil {
+		t.Fatalf("cannot serialize request: %v", err)
+	}
+
+	mockWapcClient.
+		EXPECT().
+		HostCall("kubewarden", "cache", "get", expectedPayload).
+		Return(responsePayload, nil).
+		Times(1)
+
+	host := &capabilities.Host{Client: mockWapcClient}
+
+	res, err := Get(host, "absent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected nil on cache miss, got %v", res)
+	}
+}
+
+func TestSetRejectsReservedKey(t *testing.T) {
+	mockWapcClient := &mocks.MockWapcClient{}
+
+	responsePayload, err := json.Marshal(setResponse{
+		Code:    1,
+		Message: "the key prefix 'kubewarden_internal_' is reserved",
+	})
+	if err != nil {
+		t.Fatalf("cannot serialize response: %v", err)
+	}
+
+	value := []byte{1}
+	expectedPayload, err := json.Marshal(setRequest{
+		Key:   "kubewarden_internal_x",
+		TTL:   60,
+		Value: bytesToRunes(value),
+	})
+	if err != nil {
+		t.Fatalf("cannot serialize request: %v", err)
+	}
+
+	mockWapcClient.
+		EXPECT().
+		HostCall("kubewarden", "cache", "set", expectedPayload).
+		Return(responsePayload, nil).
+		Times(1)
+
+	host := &capabilities.Host{Client: mockWapcClient}
+
+	if err := Set(host, "kubewarden_internal_x", value, 60); err == nil {
+		t.Fatal("expected an error for a reserved key, got nil")
+	}
+}

--- a/pkg/capabilities/cache/types.go
+++ b/pkg/capabilities/cache/types.go
@@ -1,0 +1,36 @@
+package cache
+
+// setRequest is the payload of a kubewarden.cache.set host call.
+type setRequest struct {
+	// Key is the unique identifier for the data being stored.
+	Key string `json:"key"`
+	// TTL is the lifespan of the entry, in seconds.
+	TTL uint64 `json:"ttl"`
+	// Value is encoded as a JSON array of numbers (like crypto.Certificate.Data),
+	// because the host expects a Vec<u8>; a Go []byte would marshal to base64.
+	Value []rune `json:"value"`
+}
+
+// getRequest is the payload of a kubewarden.cache.get host call.
+type getRequest struct {
+	// Key is the key of the data to retrieve.
+	Key string `json:"key"`
+}
+
+// setResponse is the response of a kubewarden.cache.set host call.
+type setResponse struct {
+	// Code is 0 on success, non-zero otherwise.
+	Code uint32 `json:"code"`
+	// Message is a human readable description of the outcome.
+	Message string `json:"message"`
+}
+
+// getResponse is the response of a kubewarden.cache.get host call.
+type getResponse struct {
+	// Code is 0 on success, non-zero otherwise.
+	Code uint32 `json:"code"`
+	// Message is a human readable description of the outcome.
+	Message string `json:"message"`
+	// Value is the stored data, or nil on a cache miss.
+	Value []rune `json:"value"`
+}


### PR DESCRIPTION
## Context

[[RFC 0024](https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md)](https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md) introduces a `cache` host capability that lets policy authors store and retrieve arbitrary data with their own key/TTL, instead of relying on the framework's fixed-TTL internal caches. The host side (`policy-evaluator`/`policy-server`) was implemented in [[kubewarden/adm-controller#1817](https://github.com/kubewarden/adm-controller/pull/1817)](https://github.com/kubewarden/adm-controller/pull/1817), which explicitly left the SDK wrappers (rust/go/js) as pending follow-up — without them, policies have no ergonomic way to call `kubewarden.cache.set`/`get`. This PR adds that wrapper for the Rust SDK.

## Description

Adds `set`/`get` functions to `policy-sdk-rust` for the `cache` host capability, matching the waPC namespace/operation and JSON payload contract defined on the host side.

## Refs

- RFC: https://github.com/kubewarden/rfc/blob/main/rfc/0024-cache-host-capability.md
- Host implementation: kubewarden/adm-controller#1817
- Tracking issue: kubewarden/adm-controller#1273
